### PR TITLE
SRES-3651 - update all schemas & upgrade alb to recent version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ crd_to_json_schema actions-runner-controller https://github.com/actions/actions-
 crd_to_json_schema argo-cd https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml
 crd_to_json_schema argocd-extensions https://raw.githubusercontent.com/argoproj-labs/argocd-extensions/main/manifests/crds/argoproj.io_argocdextensions.yaml
 crd_to_json_schema argo-rollouts https://raw.githubusercontent.com/argoproj/argo-rollouts/stable/manifests/install.yaml
-crd_to_json_schema aws-load-balancer-controller https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/download/v2.4.3/v2_4_3_full.yaml
+crd_to_json_schema aws-load-balancer-controller https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/download/v2.8.1/v2_8_1_full.yaml
 crd_to_json_schema cert-manager https://github.com/cert-manager/cert-manager/releases/download/v1.15.1/cert-manager.yaml
 crd_to_json_schema external-secrets https://raw.githubusercontent.com/external-secrets/external-secrets/main/deploy/crds/bundle.yaml
 crd_to_json_schema istio https://raw.githubusercontent.com/istio/istio/master/manifests/charts/base/crds/crd-all.gen.yaml

--- a/input/argo-cd.yaml
+++ b/input/argo-cd.yaml
@@ -10452,6 +10452,18 @@ spec:
                                         required:
                                         - tokenRef
                                         type: object
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
+                                      insecure:
+                                        type: boolean
                                       project:
                                         type: string
                                       repo:
@@ -10527,6 +10539,16 @@ spec:
                                     properties:
                                       api:
                                         type: string
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
                                       insecure:
                                         type: boolean
                                       labels:
@@ -11222,6 +11244,18 @@ spec:
                                         required:
                                         - tokenRef
                                         type: object
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
+                                      insecure:
+                                        type: boolean
                                       project:
                                         type: string
                                     required:
@@ -11302,6 +11336,16 @@ spec:
                                         type: boolean
                                       api:
                                         type: string
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
                                       group:
                                         type: string
                                       includeSharedProjects:
@@ -15542,6 +15586,18 @@ spec:
                                         required:
                                         - tokenRef
                                         type: object
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
+                                      insecure:
+                                        type: boolean
                                       project:
                                         type: string
                                       repo:
@@ -15617,6 +15673,16 @@ spec:
                                     properties:
                                       api:
                                         type: string
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
                                       insecure:
                                         type: boolean
                                       labels:
@@ -16312,6 +16378,18 @@ spec:
                                         required:
                                         - tokenRef
                                         type: object
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
+                                      insecure:
+                                        type: boolean
                                       project:
                                         type: string
                                     required:
@@ -16392,6 +16470,16 @@ spec:
                                         type: boolean
                                       api:
                                         type: string
+                                      caRef:
+                                        properties:
+                                          configMapName:
+                                            type: string
+                                          key:
+                                            type: string
+                                        required:
+                                        - configMapName
+                                        - key
+                                        type: object
                                       group:
                                         type: string
                                       includeSharedProjects:
@@ -18273,6 +18361,18 @@ spec:
                               required:
                               - tokenRef
                               type: object
+                            caRef:
+                              properties:
+                                configMapName:
+                                  type: string
+                                key:
+                                  type: string
+                              required:
+                              - configMapName
+                              - key
+                              type: object
+                            insecure:
+                              type: boolean
                             project:
                               type: string
                             repo:
@@ -18348,6 +18448,16 @@ spec:
                           properties:
                             api:
                               type: string
+                            caRef:
+                              properties:
+                                configMapName:
+                                  type: string
+                                key:
+                                  type: string
+                              required:
+                              - configMapName
+                              - key
+                              type: object
                             insecure:
                               type: boolean
                             labels:
@@ -19043,6 +19153,18 @@ spec:
                               required:
                               - tokenRef
                               type: object
+                            caRef:
+                              properties:
+                                configMapName:
+                                  type: string
+                                key:
+                                  type: string
+                              required:
+                              - configMapName
+                              - key
+                              type: object
+                            insecure:
+                              type: boolean
                             project:
                               type: string
                           required:
@@ -19123,6 +19245,16 @@ spec:
                               type: boolean
                             api:
                               type: string
+                            caRef:
+                              properties:
+                                configMapName:
+                                  type: string
+                                key:
+                                  type: string
+                              required:
+                              - configMapName
+                              - key
+                              type: object
                             group:
                               type: string
                             includeSharedProjects:
@@ -21918,7 +22050,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.38.0
+        image: ghcr.io/dexidp/dex:v2.40.0
         imagePullPolicy: Always
         name: dex
         ports:

--- a/input/aws-load-balancer-controller.yaml
+++ b/input/aws-load-balancer-controller.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     app.kubernetes.io/name: aws-load-balancer-controller
   name: ingressclassparams.elbv2.k8s.aws
@@ -38,18 +37,34 @@ spec:
         description: IngressClassParams is the Schema for the IngressClassParams API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             description: IngressClassParamsSpec defines the desired state of IngressClassParams
             properties:
+              certificateArn:
+                description: CertificateArn specifies the ARN of the certificates
+                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               group:
-                description: Group defines the IngressGroup for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Group defines the IngressGroup for all Ingresses that
+                  belong to IngressClass with this IngressClassParams.
                 properties:
                   name:
                     description: Name is the name of IngressGroup.
@@ -57,14 +72,24 @@ spec:
                 required:
                 - name
                 type: object
+              inboundCIDRs:
+                description: InboundCIDRs specifies the CIDRs that are allowed to
+                  access the Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               ipAddressType:
-                description: IPAddressType defines the ip address type for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: IPAddressType defines the ip address type for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
                 enum:
                 - ipv4
                 - dualstack
+                - dualstack-without-public-ipv4
                 type: string
               loadBalancerAttributes:
-                description: LoadBalancerAttributes define the custom attributes to LoadBalancers for all Ingress that that belong to IngressClass with this IngressClassParams.
+                description: LoadBalancerAttributes define the custom attributes to
+                  LoadBalancers for all Ingress that that belong to IngressClass with
+                  this IngressClassParams.
                 items:
                   description: Attributes defines custom attributes on resources.
                   properties:
@@ -80,43 +105,92 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                description: NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams. * if absent or present but empty, it selects all namespaces.
+                description: |-
+                  NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams.
+                  * if absent or present but empty, it selects all namespaces.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               scheme:
-                description: Scheme defines the scheme for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Scheme defines the scheme for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
                 enum:
                 - internal
                 - internet-facing
                 type: string
+              sslPolicy:
+                description: SSLPolicy specifies the SSL Policy for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                type: string
+              subnets:
+                description: Subnets defines the subnets for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
+                properties:
+                  ids:
+                    description: IDs specify the resource IDs of subnets. Exactly
+                      one of this or `tags` must be specified.
+                    items:
+                      description: SubnetID specifies a subnet ID.
+                      pattern: subnet-[0-9a-f]+
+                      type: string
+                    minItems: 1
+                    type: array
+                  tags:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      Tags specifies subnets in the load balancer's VPC where each
+                      tag specified in the map key contains one of the values in the corresponding
+                      value list.
+                      Exactly one of this or `ids` must be specified.
+                    type: object
+                type: object
               tags:
-                description: Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Tags defines list of Tags on AWS resources provisioned
+                  for Ingresses that belong to IngressClass with this IngressClassParams.
                 items:
                   description: Tag defines a AWS Tag on resources.
                   properties:
@@ -136,19 +210,12 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     app.kubernetes.io/name: aws-load-balancer-controller
   name: targetgroupbindings.elbv2.k8s.aws
@@ -188,10 +255,19 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -199,28 +275,39 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               networking:
-                description: networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking provides the networking setup for ELBV2 LoadBalancer
+                  to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -231,17 +318,25 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
                           items:
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: |-
+                                  The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -255,7 +350,8 @@ spec:
                     type: array
                 type: object
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -271,10 +367,12 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip
@@ -323,10 +421,19 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -334,35 +441,48 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               ipAddressType:
-                description: ipAddressType specifies whether the target group is of type IPv4 or IPv6. If unspecified, it will be automatically inferred.
+                description: ipAddressType specifies whether the target group is of
+                  type IPv4 or IPv6. If unspecified, it will be automatically inferred.
                 enum:
                 - ipv4
                 - ipv6
                 type: string
               networking:
-                description: networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking defines the networking rules to allow ELBV2
+                  LoadBalancer to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
-                      description: NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.
+                      description: NetworkingIngressRule defines a particular set
+                        of traffic that is allowed to access TargetGroup's targets.
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -373,18 +493,27 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
                           items:
-                            description: NetworkingPort defines the port and protocol for networking rules.
+                            description: NetworkingPort defines the port and protocol
+                              for networking rules.
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: |-
+                                  The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -398,37 +527,55 @@ spec:
                     type: array
                 type: object
               nodeSelector:
-                description: node selector for instance type target groups to only register certain nodes
+                description: node selector for instance type target groups to only
+                  register certain nodes
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -444,14 +591,20 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 minLength: 1
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip
+                type: string
+              vpcID:
+                description: VpcID is the VPC of the TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 type: string
             required:
             - serviceRef
@@ -470,12 +623,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -510,11 +657,26 @@ rules:
   - get
   - update
   - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - aws-load-balancer-controller-leader
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: aws-load-balancer-controller
   name: aws-load-balancer-controller-role
@@ -730,7 +892,7 @@ spec:
       - args:
         - --cluster-name=your-cluster-name
         - --ingress-class=alb
-        image: amazon/aws-alb-ingress-controller:v2.4.3
+        image: public.ecr.aws/eks/aws-load-balancer-controller:v2.8.1
         livenessProbe:
           failureThreshold: 2
           httpGet:
@@ -811,6 +973,31 @@ webhooks:
     service:
       name: aws-load-balancer-webhook-service
       namespace: kube-system
+      path: /mutate-v1-service
+  failurePolicy: Fail
+  name: mservice.elbv2.k8s.aws
+  objectSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: NotIn
+      values:
+      - aws-load-balancer-controller
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - services
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: aws-load-balancer-webhook-service
+      namespace: kube-system
       path: /mutate-v1-pod
   failurePolicy: Fail
   name: mpod.elbv2.k8s.aws
@@ -866,6 +1053,32 @@ metadata:
     app.kubernetes.io/name: aws-load-balancer-controller
   name: aws-load-balancer-webhook
 webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: aws-load-balancer-webhook-service
+      namespace: kube-system
+      path: /validate-elbv2-k8s-aws-v1beta1-ingressclassparams
+  failurePolicy: Fail
+  name: vingressclassparams.elbv2.k8s.aws
+  objectSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: NotIn
+      values:
+      - aws-load-balancer-controller
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingressclassparams
+  sideEffects: None
 - admissionReviewVersions:
   - v1beta1
   clientConfig:

--- a/input/external-secrets.yaml
+++ b/input/external-secrets.yaml
@@ -4748,6 +4748,11 @@ spec:
                             the option is enabled serverside.
                             https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                           type: boolean
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers to be added in Vault request
+                          type: object
                         namespace:
                           description: |-
                             Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
@@ -10374,6 +10379,11 @@ spec:
                             the option is enabled serverside.
                             https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                           type: boolean
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers to be added in Vault request
+                          type: object
                         namespace:
                           description: |-
                             Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
@@ -12064,6 +12074,11 @@ spec:
                         the option is enabled serverside.
                         https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                       type: boolean
+                    headers:
+                      additionalProperties:
+                        type: string
+                      description: Headers to be added in Vault request
+                      type: object
                     namespace:
                       description: |-
                         Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows

--- a/input/istio.yaml
+++ b/input/istio.yaml
@@ -538,10 +538,6 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
                                   required:
                                   - name
                                   type: object
@@ -885,10 +881,6 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
                                         required:
                                         - name
                                         type: object
@@ -1389,9 +1381,6 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
                             required:
                             - name
                             type: object
@@ -1729,10 +1718,6 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
                                   required:
                                   - name
                                   type: object
@@ -2301,10 +2286,6 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
                                   required:
                                   - name
                                   type: object
@@ -2648,10 +2629,6 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
                                         required:
                                         - name
                                         type: object
@@ -3152,9 +3129,6 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
                             required:
                             - name
                             type: object
@@ -3492,10 +3466,6 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
                                   required:
                                   - name
                                   type: object
@@ -4064,10 +4034,6 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
                                   required:
                                   - name
                                   type: object
@@ -4411,10 +4377,6 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
                                         required:
                                         - name
                                         type: object
@@ -4915,9 +4877,6 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
                             required:
                             - name
                             type: object
@@ -5255,10 +5214,6 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
                                   required:
                                   - name
                                   type: object
@@ -6588,29 +6543,48 @@ spec:
                     address:
                       description: Address associated with the network endpoint without
                         the port.
+                      maxLength: 256
                       type: string
+                      x-kubernetes-validations:
+                      - message: UDS must be an absolute path or abstract socket
+                        rule: 'self.startsWith(''unix://'') ? (self.substring(7,8)
+                          == ''/'' || self.substring(7,8) == ''@'') : true'
+                      - message: UDS may not be a dir
+                        rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'')
+                          : true'
                     labels:
                       additionalProperties:
                         type: string
                       description: One or more labels associated with the endpoint.
+                      maxProperties: 256
                       type: object
                     locality:
                       description: The locality associated with the endpoint.
+                      maxLength: 2048
                       type: string
                     network:
                       description: Network enables Istio to group endpoints resident
                         in the same L3 domain/network.
+                      maxLength: 2048
                       type: string
                     ports:
                       additionalProperties:
                         maximum: 4294967295
                         minimum: 0
                         type: integer
+                        x-kubernetes-validations:
+                        - message: port must be between 1-65535
+                          rule: 0 < self && self <= 65535
                       description: Set of ports associated with the endpoint.
+                      maxProperties: 128
                       type: object
+                      x-kubernetes-validations:
+                      - message: port name must be valid
+                        rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
                     serviceAccount:
                       description: The service account associated with the workload
                         if a sidecar is present in the workload.
+                      maxLength: 253
                       type: string
                     weight:
                       description: The load balancing weight associated with the endpoint.
@@ -6618,6 +6592,13 @@ spec:
                       minimum: 0
                       type: integer
                   type: object
+                  x-kubernetes-validations:
+                  - message: Address is required
+                    rule: has(self.address) || has(self.network)
+                  - message: UDS may not include ports
+                    rule: '(has(self.address) && self.address.startsWith(''unix://''))
+                      ? !has(self.ports) : true'
+                maxItems: 4096
                 type: array
               exportTo:
                 description: A list of namespaces to which this service is exported.
@@ -6744,29 +6725,48 @@ spec:
                     address:
                       description: Address associated with the network endpoint without
                         the port.
+                      maxLength: 256
                       type: string
+                      x-kubernetes-validations:
+                      - message: UDS must be an absolute path or abstract socket
+                        rule: 'self.startsWith(''unix://'') ? (self.substring(7,8)
+                          == ''/'' || self.substring(7,8) == ''@'') : true'
+                      - message: UDS may not be a dir
+                        rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'')
+                          : true'
                     labels:
                       additionalProperties:
                         type: string
                       description: One or more labels associated with the endpoint.
+                      maxProperties: 256
                       type: object
                     locality:
                       description: The locality associated with the endpoint.
+                      maxLength: 2048
                       type: string
                     network:
                       description: Network enables Istio to group endpoints resident
                         in the same L3 domain/network.
+                      maxLength: 2048
                       type: string
                     ports:
                       additionalProperties:
                         maximum: 4294967295
                         minimum: 0
                         type: integer
+                        x-kubernetes-validations:
+                        - message: port must be between 1-65535
+                          rule: 0 < self && self <= 65535
                       description: Set of ports associated with the endpoint.
+                      maxProperties: 128
                       type: object
+                      x-kubernetes-validations:
+                      - message: port name must be valid
+                        rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
                     serviceAccount:
                       description: The service account associated with the workload
                         if a sidecar is present in the workload.
+                      maxLength: 253
                       type: string
                     weight:
                       description: The load balancing weight associated with the endpoint.
@@ -6774,6 +6774,13 @@ spec:
                       minimum: 0
                       type: integer
                   type: object
+                  x-kubernetes-validations:
+                  - message: Address is required
+                    rule: has(self.address) || has(self.network)
+                  - message: UDS may not include ports
+                    rule: '(has(self.address) && self.address.startsWith(''unix://''))
+                      ? !has(self.ports) : true'
+                maxItems: 4096
                 type: array
               exportTo:
                 description: A list of namespaces to which this service is exported.
@@ -6900,29 +6907,48 @@ spec:
                     address:
                       description: Address associated with the network endpoint without
                         the port.
+                      maxLength: 256
                       type: string
+                      x-kubernetes-validations:
+                      - message: UDS must be an absolute path or abstract socket
+                        rule: 'self.startsWith(''unix://'') ? (self.substring(7,8)
+                          == ''/'' || self.substring(7,8) == ''@'') : true'
+                      - message: UDS may not be a dir
+                        rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'')
+                          : true'
                     labels:
                       additionalProperties:
                         type: string
                       description: One or more labels associated with the endpoint.
+                      maxProperties: 256
                       type: object
                     locality:
                       description: The locality associated with the endpoint.
+                      maxLength: 2048
                       type: string
                     network:
                       description: Network enables Istio to group endpoints resident
                         in the same L3 domain/network.
+                      maxLength: 2048
                       type: string
                     ports:
                       additionalProperties:
                         maximum: 4294967295
                         minimum: 0
                         type: integer
+                        x-kubernetes-validations:
+                        - message: port must be between 1-65535
+                          rule: 0 < self && self <= 65535
                       description: Set of ports associated with the endpoint.
+                      maxProperties: 128
                       type: object
+                      x-kubernetes-validations:
+                      - message: port name must be valid
+                        rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
                     serviceAccount:
                       description: The service account associated with the workload
                         if a sidecar is present in the workload.
+                      maxLength: 253
                       type: string
                     weight:
                       description: The load balancing weight associated with the endpoint.
@@ -6930,6 +6956,13 @@ spec:
                       minimum: 0
                       type: integer
                   type: object
+                  x-kubernetes-validations:
+                  - message: Address is required
+                    rule: has(self.address) || has(self.network)
+                  - message: UDS may not include ports
+                    rule: '(has(self.address) && self.address.startsWith(''unix://''))
+                      ? !has(self.ports) : true'
+                maxItems: 4096
                 type: array
               exportTo:
                 description: A list of namespaces to which this service is exported.
@@ -11410,29 +11443,47 @@ spec:
               address:
                 description: Address associated with the network endpoint without
                   the port.
+                maxLength: 256
                 type: string
+                x-kubernetes-validations:
+                - message: UDS must be an absolute path or abstract socket
+                  rule: 'self.startsWith(''unix://'') ? (self.substring(7,8) == ''/''
+                    || self.substring(7,8) == ''@'') : true'
+                - message: UDS may not be a dir
+                  rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'') : true'
               labels:
                 additionalProperties:
                   type: string
                 description: One or more labels associated with the endpoint.
+                maxProperties: 256
                 type: object
               locality:
                 description: The locality associated with the endpoint.
+                maxLength: 2048
                 type: string
               network:
                 description: Network enables Istio to group endpoints resident in
                   the same L3 domain/network.
+                maxLength: 2048
                 type: string
               ports:
                 additionalProperties:
                   maximum: 4294967295
                   minimum: 0
                   type: integer
+                  x-kubernetes-validations:
+                  - message: port must be between 1-65535
+                    rule: 0 < self && self <= 65535
                 description: Set of ports associated with the endpoint.
+                maxProperties: 128
                 type: object
+                x-kubernetes-validations:
+                - message: port name must be valid
+                  rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
               serviceAccount:
                 description: The service account associated with the workload if a
                   sidecar is present in the workload.
+                maxLength: 253
                 type: string
               weight:
                 description: The load balancing weight associated with the endpoint.
@@ -11440,9 +11491,19 @@ spec:
                 minimum: 0
                 type: integer
             type: object
+            x-kubernetes-validations:
+            - message: Address is required
+              rule: has(self.address) || has(self.network)
+            - message: UDS may not include ports
+              rule: '(has(self.address) && self.address.startsWith(''unix://'')) ?
+                !has(self.ports) : true'
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        - spec
+        - spec
         type: object
     served: true
     storage: false
@@ -11472,29 +11533,47 @@ spec:
               address:
                 description: Address associated with the network endpoint without
                   the port.
+                maxLength: 256
                 type: string
+                x-kubernetes-validations:
+                - message: UDS must be an absolute path or abstract socket
+                  rule: 'self.startsWith(''unix://'') ? (self.substring(7,8) == ''/''
+                    || self.substring(7,8) == ''@'') : true'
+                - message: UDS may not be a dir
+                  rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'') : true'
               labels:
                 additionalProperties:
                   type: string
                 description: One or more labels associated with the endpoint.
+                maxProperties: 256
                 type: object
               locality:
                 description: The locality associated with the endpoint.
+                maxLength: 2048
                 type: string
               network:
                 description: Network enables Istio to group endpoints resident in
                   the same L3 domain/network.
+                maxLength: 2048
                 type: string
               ports:
                 additionalProperties:
                   maximum: 4294967295
                   minimum: 0
                   type: integer
+                  x-kubernetes-validations:
+                  - message: port must be between 1-65535
+                    rule: 0 < self && self <= 65535
                 description: Set of ports associated with the endpoint.
+                maxProperties: 128
                 type: object
+                x-kubernetes-validations:
+                - message: port name must be valid
+                  rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
               serviceAccount:
                 description: The service account associated with the workload if a
                   sidecar is present in the workload.
+                maxLength: 253
                 type: string
               weight:
                 description: The load balancing weight associated with the endpoint.
@@ -11502,9 +11581,19 @@ spec:
                 minimum: 0
                 type: integer
             type: object
+            x-kubernetes-validations:
+            - message: Address is required
+              rule: has(self.address) || has(self.network)
+            - message: UDS may not include ports
+              rule: '(has(self.address) && self.address.startsWith(''unix://'')) ?
+                !has(self.ports) : true'
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        - spec
+        - spec
         type: object
     served: true
     storage: false
@@ -11534,29 +11623,47 @@ spec:
               address:
                 description: Address associated with the network endpoint without
                   the port.
+                maxLength: 256
                 type: string
+                x-kubernetes-validations:
+                - message: UDS must be an absolute path or abstract socket
+                  rule: 'self.startsWith(''unix://'') ? (self.substring(7,8) == ''/''
+                    || self.substring(7,8) == ''@'') : true'
+                - message: UDS may not be a dir
+                  rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'') : true'
               labels:
                 additionalProperties:
                   type: string
                 description: One or more labels associated with the endpoint.
+                maxProperties: 256
                 type: object
               locality:
                 description: The locality associated with the endpoint.
+                maxLength: 2048
                 type: string
               network:
                 description: Network enables Istio to group endpoints resident in
                   the same L3 domain/network.
+                maxLength: 2048
                 type: string
               ports:
                 additionalProperties:
                   maximum: 4294967295
                   minimum: 0
                   type: integer
+                  x-kubernetes-validations:
+                  - message: port must be between 1-65535
+                    rule: 0 < self && self <= 65535
                 description: Set of ports associated with the endpoint.
+                maxProperties: 128
                 type: object
+                x-kubernetes-validations:
+                - message: port name must be valid
+                  rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
               serviceAccount:
                 description: The service account associated with the workload if a
                   sidecar is present in the workload.
+                maxLength: 253
                 type: string
               weight:
                 description: The load balancing weight associated with the endpoint.
@@ -11564,9 +11671,19 @@ spec:
                 minimum: 0
                 type: integer
             type: object
+            x-kubernetes-validations:
+            - message: Address is required
+              rule: has(self.address) || has(self.network)
+            - message: UDS may not include ports
+              rule: '(has(self.address) && self.address.startsWith(''unix://'')) ?
+                !has(self.ports) : true'
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        - spec
+        - spec
         type: object
     served: true
     storage: true
@@ -11728,29 +11845,48 @@ spec:
                   address:
                     description: Address associated with the network endpoint without
                       the port.
+                    maxLength: 256
                     type: string
+                    x-kubernetes-validations:
+                    - message: UDS must be an absolute path or abstract socket
+                      rule: 'self.startsWith(''unix://'') ? (self.substring(7,8) ==
+                        ''/'' || self.substring(7,8) == ''@'') : true'
+                    - message: UDS may not be a dir
+                      rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'')
+                        : true'
                   labels:
                     additionalProperties:
                       type: string
                     description: One or more labels associated with the endpoint.
+                    maxProperties: 256
                     type: object
                   locality:
                     description: The locality associated with the endpoint.
+                    maxLength: 2048
                     type: string
                   network:
                     description: Network enables Istio to group endpoints resident
                       in the same L3 domain/network.
+                    maxLength: 2048
                     type: string
                   ports:
                     additionalProperties:
                       maximum: 4294967295
                       minimum: 0
                       type: integer
+                      x-kubernetes-validations:
+                      - message: port must be between 1-65535
+                        rule: 0 < self && self <= 65535
                     description: Set of ports associated with the endpoint.
+                    maxProperties: 128
                     type: object
+                    x-kubernetes-validations:
+                    - message: port name must be valid
+                      rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
                   serviceAccount:
                     description: The service account associated with the workload
                       if a sidecar is present in the workload.
+                    maxLength: 253
                     type: string
                   weight:
                     description: The load balancing weight associated with the endpoint.
@@ -11758,6 +11894,12 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: Address is required
+                  rule: has(self.address) || has(self.network)
+                - message: UDS may not include ports
+                  rule: '(has(self.address) && self.address.startsWith(''unix://''))
+                    ? !has(self.ports) : true'
             required:
             - template
             type: object
@@ -11901,29 +12043,48 @@ spec:
                   address:
                     description: Address associated with the network endpoint without
                       the port.
+                    maxLength: 256
                     type: string
+                    x-kubernetes-validations:
+                    - message: UDS must be an absolute path or abstract socket
+                      rule: 'self.startsWith(''unix://'') ? (self.substring(7,8) ==
+                        ''/'' || self.substring(7,8) == ''@'') : true'
+                    - message: UDS may not be a dir
+                      rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'')
+                        : true'
                   labels:
                     additionalProperties:
                       type: string
                     description: One or more labels associated with the endpoint.
+                    maxProperties: 256
                     type: object
                   locality:
                     description: The locality associated with the endpoint.
+                    maxLength: 2048
                     type: string
                   network:
                     description: Network enables Istio to group endpoints resident
                       in the same L3 domain/network.
+                    maxLength: 2048
                     type: string
                   ports:
                     additionalProperties:
                       maximum: 4294967295
                       minimum: 0
                       type: integer
+                      x-kubernetes-validations:
+                      - message: port must be between 1-65535
+                        rule: 0 < self && self <= 65535
                     description: Set of ports associated with the endpoint.
+                    maxProperties: 128
                     type: object
+                    x-kubernetes-validations:
+                    - message: port name must be valid
+                      rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
                   serviceAccount:
                     description: The service account associated with the workload
                       if a sidecar is present in the workload.
+                    maxLength: 253
                     type: string
                   weight:
                     description: The load balancing weight associated with the endpoint.
@@ -11931,6 +12092,12 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: Address is required
+                  rule: has(self.address) || has(self.network)
+                - message: UDS may not include ports
+                  rule: '(has(self.address) && self.address.startsWith(''unix://''))
+                    ? !has(self.ports) : true'
             required:
             - template
             type: object
@@ -12074,29 +12241,48 @@ spec:
                   address:
                     description: Address associated with the network endpoint without
                       the port.
+                    maxLength: 256
                     type: string
+                    x-kubernetes-validations:
+                    - message: UDS must be an absolute path or abstract socket
+                      rule: 'self.startsWith(''unix://'') ? (self.substring(7,8) ==
+                        ''/'' || self.substring(7,8) == ''@'') : true'
+                    - message: UDS may not be a dir
+                      rule: 'self.startsWith(''unix://'') ? !self.endsWith(''/'')
+                        : true'
                   labels:
                     additionalProperties:
                       type: string
                     description: One or more labels associated with the endpoint.
+                    maxProperties: 256
                     type: object
                   locality:
                     description: The locality associated with the endpoint.
+                    maxLength: 2048
                     type: string
                   network:
                     description: Network enables Istio to group endpoints resident
                       in the same L3 domain/network.
+                    maxLength: 2048
                     type: string
                   ports:
                     additionalProperties:
                       maximum: 4294967295
                       minimum: 0
                       type: integer
+                      x-kubernetes-validations:
+                      - message: port must be between 1-65535
+                        rule: 0 < self && self <= 65535
                     description: Set of ports associated with the endpoint.
+                    maxProperties: 128
                     type: object
+                    x-kubernetes-validations:
+                    - message: port name must be valid
+                      rule: self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))
                   serviceAccount:
                     description: The service account associated with the workload
                       if a sidecar is present in the workload.
+                    maxLength: 253
                     type: string
                   weight:
                     description: The load balancing weight associated with the endpoint.
@@ -12104,6 +12290,12 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: Address is required
+                  rule: has(self.address) || has(self.network)
+                - message: UDS may not include ports
+                  rule: '(has(self.address) && self.address.startsWith(''unix://''))
+                    ? !has(self.ports) : true'
             required:
             - template
             type: object

--- a/input/kargo-freights.yaml
+++ b/input/kargo-freights.yaml
@@ -18,6 +18,12 @@ spec:
     - jsonPath: .metadata.labels.kargo\.akuity\.io/alias
       name: Alias
       type: string
+    - jsonPath: .origin.kind
+      name: Origin (Kind)
+      type: string
+    - jsonPath: .origin.name
+      name: Origin (Name)
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -86,7 +92,7 @@ spec:
                 healthCheckCommit:
                   description: |-
                     HealthCheckCommit is the ID of a specific commit. When specified,
-                    assessments of Stage health will used this value (instead of ID) when
+                    assessments of Stage health will use this value (instead of ID) when
                     determining if applicable sources of Argo CD Application resources
                     associated with the Stage are or are not synced to this commit. Note that
                     there are cases (as in that of Kargo Render being utilized as a promotion
@@ -151,6 +157,25 @@ spec:
             type: string
           metadata:
             type: object
+          origin:
+            description: Origin describes a kind of Freight in terms of its origin.
+            properties:
+              kind:
+                description: |-
+                  Kind is the kind of resource from which Freight may have originated. At
+                  present, this can only be "Warehouse".
+                enum:
+                - Warehouse
+                type: string
+              name:
+                description: |-
+                  Name is the name of the resource of the kind indicated by the Kind field
+                  from which Freight may originated.
+                type: string
+            required:
+            - kind
+            - name
+            type: object
           status:
             description: Status describes the current status of this Freight.
             properties:
@@ -181,6 +206,9 @@ spec:
               Warehouse is the name of the Warehouse that created this Freight. This is a
               required field. TODO: It is not clear yet how this field should be set in
               the case of user-defined Freight.
+
+
+              Deprecated: Use Origin instead.
             type: string
         type: object
     served: true

--- a/input/kargo-promotions.yaml
+++ b/input/kargo-promotions.yaml
@@ -136,7 +136,7 @@ spec:
                         healthCheckCommit:
                           description: |-
                             HealthCheckCommit is the ID of a specific commit. When specified,
-                            assessments of Stage health will used this value (instead of ID) when
+                            assessments of Stage health will use this value (instead of ID) when
                             determining if applicable sources of Argo CD Application resources
                             associated with the Stage are or are not synced to this commit. Note that
                             there are cases (as in that of Kargo Render being utilized as a promotion
@@ -198,14 +198,37 @@ spec:
                       the contents of the Freight. i.e. Two pieces of Freight can be compared for
                       equality by comparing their Names.
                     type: string
+                  origin:
+                    description: Origin describes a kind of Freight in terms of its
+                      origin.
+                    properties:
+                      kind:
+                        description: |-
+                          Kind is the kind of resource from which Freight may have originated. At
+                          present, this can only be "Warehouse".
+                        enum:
+                        - Warehouse
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the resource of the kind indicated by the Kind field
+                          from which Freight may originated.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
                   verificationHistory:
                     description: |-
                       VerificationHistory is a stack of recent VerificationInfo. By default,
                       the last ten VerificationInfo are stored.
+
+
+                      Deprecated: Use FreightCollection.VerificationHistory instead.
                     items:
                       description: |-
-                        VerificationInfo contains information about the currently running
-                        Verification process.
+                        VerificationInfo contains the details of an instance of a Verification
+                        process.
                       properties:
                         actor:
                           description: |-
@@ -263,6 +286,9 @@ spec:
                     description: |-
                       VerificationInfo is information about any verification process that was
                       associated with this Freight for this Stage.
+
+
+                      Deprecated: Use FreightCollection.VerificationHistory instead.
                     properties:
                       actor:
                         description: |-
@@ -316,9 +342,358 @@ spec:
                         type: string
                     type: object
                   warehouse:
-                    description: Warehouse is the name of the Warehouse that created
-                      this Freight.
+                    description: |-
+                      Warehouse is the name of the Warehouse that created this Freight.
+
+
+                      Deprecated: Use the Origin instead.
                     type: string
+                type: object
+              freightCollection:
+                description: |-
+                  FreightCollection contains the details of the piece of Freight referenced
+                  by this Promotion as well as any additional Freight that is carried over
+                  from the target Stage's current state.
+                properties:
+                  id:
+                    description: |-
+                      ID is a unique and deterministically calculated identifier for the
+                      FreightCollection. It is updated on each use of the UpdateOrPush method.
+                    type: string
+                  items:
+                    additionalProperties:
+                      description: |-
+                        FreightReference is a simplified representation of a piece of Freight -- not
+                        a root resource type.
+                      properties:
+                        charts:
+                          description: Charts describes specific versions of specific
+                            Helm charts.
+                          items:
+                            description: Chart describes a specific version of a Helm
+                              chart.
+                            properties:
+                              name:
+                                description: Name specifies the name of the chart.
+                                type: string
+                              repoURL:
+                                description: |-
+                                  RepoURL specifies the URL of a Helm chart repository. Classic chart
+                                  repositories (using HTTP/S) can contain differently named charts. When this
+                                  field points to such a repository, the Name field will specify the name of
+                                  the chart within the repository. In the case of a repository within an OCI
+                                  registry, the URL implicitly points to a specific chart and the Name field
+                                  will be empty.
+                                type: string
+                              version:
+                                description: Version specifies a particular version
+                                  of the chart.
+                                type: string
+                            type: object
+                          type: array
+                        commits:
+                          description: Commits describes specific Git repository commits.
+                          items:
+                            description: GitCommit describes a specific commit from
+                              a specific Git repository.
+                            properties:
+                              author:
+                                description: Author is the author of the commit.
+                                type: string
+                              branch:
+                                description: Branch denotes the branch of the repository
+                                  where this commit was found.
+                                type: string
+                              committer:
+                                description: Committer is the person who committed
+                                  the commit.
+                                type: string
+                              healthCheckCommit:
+                                description: |-
+                                  HealthCheckCommit is the ID of a specific commit. When specified,
+                                  assessments of Stage health will use this value (instead of ID) when
+                                  determining if applicable sources of Argo CD Application resources
+                                  associated with the Stage are or are not synced to this commit. Note that
+                                  there are cases (as in that of Kargo Render being utilized as a promotion
+                                  mechanism) wherein the value of this field may differ from the commit ID
+                                  found in the ID field.
+                                type: string
+                              id:
+                                description: |-
+                                  ID is the ID of a specific commit in the Git repository specified by
+                                  RepoURL.
+                                type: string
+                              message:
+                                description: |-
+                                  Message is the message associated with the commit. At present, this only
+                                  contains the first line (subject) of the commit message.
+                                type: string
+                              repoURL:
+                                description: RepoURL is the URL of a Git repository.
+                                type: string
+                              tag:
+                                description: |-
+                                  Tag denotes a tag in the repository that matched selection criteria and
+                                  resolved to this commit.
+                                type: string
+                            type: object
+                          type: array
+                        images:
+                          description: Images describes specific versions of specific
+                            container images.
+                          items:
+                            description: Image describes a specific version of a container
+                              image.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest identifies a specific version of the image in the repository
+                                  specified by RepoURL. This is a more precise identifier than Tag.
+                                type: string
+                              gitRepoURL:
+                                description: |-
+                                  GitRepoURL specifies the URL of a Git repository that contains the source
+                                  code for the image repository referenced by the RepoURL field if Kargo was
+                                  able to infer it.
+                                type: string
+                              repoURL:
+                                description: RepoURL describes the repository in which
+                                  the image can be found.
+                                type: string
+                              tag:
+                                description: |-
+                                  Tag identifies a specific version of the image in the repository specified
+                                  by RepoURL.
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          description: |-
+                            Name is system-assigned identifier that is derived deterministically from
+                            the contents of the Freight. i.e. Two pieces of Freight can be compared for
+                            equality by comparing their Names.
+                          type: string
+                        origin:
+                          description: Origin describes a kind of Freight in terms
+                            of its origin.
+                          properties:
+                            kind:
+                              description: |-
+                                Kind is the kind of resource from which Freight may have originated. At
+                                present, this can only be "Warehouse".
+                              enum:
+                              - Warehouse
+                              type: string
+                            name:
+                              description: |-
+                                Name is the name of the resource of the kind indicated by the Kind field
+                                from which Freight may originated.
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        verificationHistory:
+                          description: |-
+                            VerificationHistory is a stack of recent VerificationInfo. By default,
+                            the last ten VerificationInfo are stored.
+
+
+                            Deprecated: Use FreightCollection.VerificationHistory instead.
+                          items:
+                            description: |-
+                              VerificationInfo contains the details of an instance of a Verification
+                              process.
+                            properties:
+                              actor:
+                                description: |-
+                                  Actor is the name of the entity that initiated or aborted the
+                                  Verification process.
+                                type: string
+                              analysisRun:
+                                description: |-
+                                  AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                  the Verification process.
+                                properties:
+                                  name:
+                                    description: Name is the name of the AnalysisRun.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the namespace of the
+                                      AnalysisRun.
+                                    type: string
+                                  phase:
+                                    description: Phase is the last observed phase
+                                      of the AnalysisRun referenced by Name.
+                                    type: string
+                                required:
+                                - name
+                                - namespace
+                                - phase
+                                type: object
+                              finishTime:
+                                description: FinishTime is the time at which the Verification
+                                  process finished.
+                                format: date-time
+                                type: string
+                              id:
+                                description: ID is the identifier of the Verification
+                                  process.
+                                type: string
+                              message:
+                                description: |-
+                                  Message may contain additional information about why the verification
+                                  process is in its current phase.
+                                type: string
+                              phase:
+                                description: |-
+                                  Phase describes the current phase of the Verification process. Generally,
+                                  this will be a reflection of the underlying AnalysisRun's phase, however,
+                                  there are exceptions to this, such as in the case where an AnalysisRun
+                                  cannot be launched successfully.
+                                type: string
+                              startTime:
+                                description: StartTime is the time at which the Verification
+                                  process was started.
+                                format: date-time
+                                type: string
+                            type: object
+                          type: array
+                        verificationInfo:
+                          description: |-
+                            VerificationInfo is information about any verification process that was
+                            associated with this Freight for this Stage.
+
+
+                            Deprecated: Use FreightCollection.VerificationHistory instead.
+                          properties:
+                            actor:
+                              description: |-
+                                Actor is the name of the entity that initiated or aborted the
+                                Verification process.
+                              type: string
+                            analysisRun:
+                              description: |-
+                                AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                the Verification process.
+                              properties:
+                                name:
+                                  description: Name is the name of the AnalysisRun.
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of the AnalysisRun.
+                                  type: string
+                                phase:
+                                  description: Phase is the last observed phase of
+                                    the AnalysisRun referenced by Name.
+                                  type: string
+                              required:
+                              - name
+                              - namespace
+                              - phase
+                              type: object
+                            finishTime:
+                              description: FinishTime is the time at which the Verification
+                                process finished.
+                              format: date-time
+                              type: string
+                            id:
+                              description: ID is the identifier of the Verification
+                                process.
+                              type: string
+                            message:
+                              description: |-
+                                Message may contain additional information about why the verification
+                                process is in its current phase.
+                              type: string
+                            phase:
+                              description: |-
+                                Phase describes the current phase of the Verification process. Generally,
+                                this will be a reflection of the underlying AnalysisRun's phase, however,
+                                there are exceptions to this, such as in the case where an AnalysisRun
+                                cannot be launched successfully.
+                              type: string
+                            startTime:
+                              description: StartTime is the time at which the Verification
+                                process was started.
+                              format: date-time
+                              type: string
+                          type: object
+                        warehouse:
+                          description: |-
+                            Warehouse is the name of the Warehouse that created this Freight.
+
+
+                            Deprecated: Use the Origin instead.
+                          type: string
+                      type: object
+                    description: |-
+                      Freight is a map of FreightReference objects, indexed by their Warehouse
+                      origin.
+                    type: object
+                  verificationHistory:
+                    description: |-
+                      VerificationHistory is a stack of recent VerificationInfo. By default,
+                      the last ten VerificationInfo are stored.
+                    items:
+                      description: |-
+                        VerificationInfo contains the details of an instance of a Verification
+                        process.
+                      properties:
+                        actor:
+                          description: |-
+                            Actor is the name of the entity that initiated or aborted the
+                            Verification process.
+                          type: string
+                        analysisRun:
+                          description: |-
+                            AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                            the Verification process.
+                          properties:
+                            name:
+                              description: Name is the name of the AnalysisRun.
+                              type: string
+                            namespace:
+                              description: Namespace is the namespace of the AnalysisRun.
+                              type: string
+                            phase:
+                              description: Phase is the last observed phase of the
+                                AnalysisRun referenced by Name.
+                              type: string
+                          required:
+                          - name
+                          - namespace
+                          - phase
+                          type: object
+                        finishTime:
+                          description: FinishTime is the time at which the Verification
+                            process finished.
+                          format: date-time
+                          type: string
+                        id:
+                          description: ID is the identifier of the Verification process.
+                          type: string
+                        message:
+                          description: |-
+                            Message may contain additional information about why the verification
+                            process is in its current phase.
+                          type: string
+                        phase:
+                          description: |-
+                            Phase describes the current phase of the Verification process. Generally,
+                            this will be a reflection of the underlying AnalysisRun's phase, however,
+                            there are exceptions to this, such as in the case where an AnalysisRun
+                            cannot be launched successfully.
+                          type: string
+                        startTime:
+                          description: StartTime is the time at which the Verification
+                            process was started.
+                          format: date-time
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - id
                 type: object
               lastHandledRefresh:
                 description: |-

--- a/input/kargo-stages.yaml
+++ b/input/kargo-stages.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .spec.shard
       name: Shard
       type: string
-    - jsonPath: .status.currentFreight.name
+    - jsonPath: .status.freightSummary
       name: Current Freight
       type: string
     - jsonPath: .status.health.status
@@ -92,6 +92,32 @@ spec:
                             will use the value of ARGOCD_NAMESPACE or "argocd"
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
+                        origin:
+                          description: |-
+                            Origin disambiguates the origin from which artifacts used by this promotion
+                            mechanism must have originated. This is especially useful in cases where a
+                            Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                            and some of those each reference different versions of artifacts from the
+                            same repository. This field is optional, but Promotions will fail if there
+                            is ever ambiguity regarding which piece of Freight from which an artifact
+                            is to be sourced.
+                          properties:
+                            kind:
+                              description: |-
+                                Kind is the kind of resource from which Freight may have originated. At
+                                present, this can only be "Warehouse".
+                              enum:
+                              - Warehouse
+                              type: string
+                            name:
+                              description: |-
+                                Name is the name of the resource of the kind indicated by the Kind field
+                                from which Freight may originated.
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
                         sourceUpdates:
                           description: |-
                             SourceUpdates describes updates to be applied to various sources of the
@@ -136,6 +162,33 @@ spec:
                                             to be updated. This is a required field.
                                           minLength: 1
                                           type: string
+                                        origin:
+                                          description: |-
+                                            Origin disambiguates the origin from which artifacts used by this promotion
+                                            mechanism must have originated. This is especially useful in cases where a
+                                            Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                            and some of those each reference different versions of artifacts from the
+                                            same repository. This field is optional. When left unspecified, it will
+                                            implicitly inherit the value of the enclosing ArgoCDHelm's Origin field. If
+                                            that, too, is unspecified, Promotions will fail if there is ever ambiguity
+                                            regarding from which piece of Freight an artifact is to be sourced.
+                                          properties:
+                                            kind:
+                                              description: |-
+                                                Kind is the kind of resource from which Freight may have originated. At
+                                                present, this can only be "Warehouse".
+                                              enum:
+                                              - Warehouse
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name is the name of the resource of the kind indicated by the Kind field
+                                                from which Freight may originated.
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
                                         value:
                                           description: |-
                                             Value specifies the new value for the specified key in the Argo CD
@@ -164,6 +217,34 @@ spec:
                                       type: object
                                     minItems: 1
                                     type: array
+                                  origin:
+                                    description: |-
+                                      Origin disambiguates the origin from which artifacts used by this promotion
+                                      mechanism must have originated. This is especially useful in cases where a
+                                      Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                      and some of those each reference different versions of artifacts from the
+                                      same repository. This field is optional. When left unspecified, it will
+                                      implicitly inherit the value of the enclosing ArgoCDSourceUpdate's Origin
+                                      field. If that, too, is unspecified, Promotions will fail if there is ever
+                                      ambiguity regarding from which piece of Freight an artifact is to be
+                                      sourced.
+                                    properties:
+                                      kind:
+                                        description: |-
+                                          Kind is the kind of resource from which Freight may have originated. At
+                                          present, this can only be "Warehouse".
+                                        enum:
+                                        - Warehouse
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name is the name of the resource of the kind indicated by the Kind field
+                                          from which Freight may originated.
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
                                 required:
                                 - images
                                 type: object
@@ -186,6 +267,34 @@ spec:
                                             field.
                                           minLength: 1
                                           type: string
+                                        origin:
+                                          description: |-
+                                            Origin disambiguates the origin from which artifacts used by this promotion
+                                            mechanism must have originated. This is especially useful in cases where a
+                                            Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                            and some of those each reference different versions of artifacts from the
+                                            same repository. This field is optional. When left unspecified, it will
+                                            implicitly inherit the value of the enclosing ArgoCDKustomize's Origin
+                                            field. If that, too, is unspecified, Promotions will fail if there is ever
+                                            ambiguity regarding from which piece of Freight an artifact is to be
+                                            sourced.
+                                          properties:
+                                            kind:
+                                              description: |-
+                                                Kind is the kind of resource from which Freight may have originated. At
+                                                present, this can only be "Warehouse".
+                                              enum:
+                                              - Warehouse
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name is the name of the resource of the kind indicated by the Kind field
+                                                from which Freight may originated.
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
                                         useDigest:
                                           description: |-
                                             UseDigest specifies whether the image's digest should be used instead of
@@ -196,8 +305,64 @@ spec:
                                       type: object
                                     minItems: 1
                                     type: array
+                                  origin:
+                                    description: |-
+                                      Origin disambiguates the origin from which artifacts used by this promotion
+                                      mechanism must have originated. This is especially useful in cases where a
+                                      Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                      and some of those each reference different versions of artifacts from the
+                                      same repository. This field is optional. When left unspecified, it will
+                                      implicitly inherit the value of the enclosing ArgoCDSourceUpdate's Origin
+                                      field. If that, too, is unspecified, Promotions will fail if there is ever
+                                      ambiguity regarding from which piece of Freight an artifact is to be
+                                      sourced.
+                                    properties:
+                                      kind:
+                                        description: |-
+                                          Kind is the kind of resource from which Freight may have originated. At
+                                          present, this can only be "Warehouse".
+                                        enum:
+                                        - Warehouse
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name is the name of the resource of the kind indicated by the Kind field
+                                          from which Freight may originated.
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
                                 required:
                                 - images
+                                type: object
+                              origin:
+                                description: |-
+                                  Origin disambiguates the origin from which artifacts used by this promotion
+                                  mechanism must have originated. This is especially useful in cases where a
+                                  Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                  and some of those each reference different versions of artifacts from the
+                                  same repository. This field is optional. When left unspecified, it will
+                                  implicitly inherit the value of the enclosing ArgoCDAppUpdate's Origin
+                                  field. If that, too, is unspecified, Promotions will fail if there is ever
+                                  ambiguity regarding from which piece of Freight an artifact is to be
+                                  sourced.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind is the kind of resource from which Freight may have originated. At
+                                      present, this can only be "Warehouse".
+                                    enum:
+                                    - Warehouse
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of the resource of the kind indicated by the Kind field
+                                      from which Freight may originated.
+                                    type: string
+                                required:
+                                - kind
+                                - name
                                 type: object
                               repoURL:
                                 description: |-
@@ -267,6 +432,34 @@ spec:
                                       Chart.yaml. This is a required field.
                                     minLength: 1
                                     type: string
+                                  origin:
+                                    description: |-
+                                      Origin disambiguates the origin from which artifacts used by this promotion
+                                      mechanism must have originated. This is especially useful in cases where a
+                                      Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                      and some of those each reference different versions of artifacts from the
+                                      same repository. This field is optional. When left unspecified, it will
+                                      implicitly inherit the value of the enclosing HelmPromotionMechanism's
+                                      Origin field. If that, too, is unspecified, Promotions will fail if there
+                                      is ever ambiguity regarding from which piece of Freight an artifact is to
+                                      be sourced.
+                                    properties:
+                                      kind:
+                                        description: |-
+                                          Kind is the kind of resource from which Freight may have originated. At
+                                          present, this can only be "Warehouse".
+                                        enum:
+                                        - Warehouse
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name is the name of the resource of the kind indicated by the Kind field
+                                          from which Freight may originated.
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
                                   repository:
                                     description: |-
                                       Repository along with Name identifies a subchart of the umbrella chart at
@@ -305,6 +498,34 @@ spec:
                                       is a required field.
                                     minLength: 1
                                     type: string
+                                  origin:
+                                    description: |-
+                                      Origin disambiguates the origin from which artifacts used by this promotion
+                                      mechanism must have originated. This is especially useful in cases where a
+                                      Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                      and some of those each reference different versions of artifacts from the
+                                      same repository. This field is optional. When left unspecified, it will
+                                      implicitly inherit the value of the enclosing HelmPromotionMechanism's
+                                      Origin field. If that, too, is unspecified, Promotions will fail if there
+                                      is ever ambiguity regarding from which piece of Freight an artifact is to
+                                      be sourced.
+                                    properties:
+                                      kind:
+                                        description: |-
+                                          Kind is the kind of resource from which Freight may have originated. At
+                                          present, this can only be "Warehouse".
+                                        enum:
+                                        - Warehouse
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name is the name of the resource of the kind indicated by the Kind field
+                                          from which Freight may originated.
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
                                   value:
                                     description: |-
                                       Value specifies the new value for the specified key in the specified Helm
@@ -340,6 +561,34 @@ spec:
                                 - valuesFilePath
                                 type: object
                               type: array
+                            origin:
+                              description: |-
+                                Origin disambiguates the origin from which artifacts used by this promotion
+                                mechanism must have originated. This is especially useful in cases where a
+                                Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                and some of those each reference different versions of artifacts from the
+                                same repository. This field is optional. When left unspecified, it will
+                                implicitly inherit the value of the enclosing GitRepoUpdate's Origin field.
+                                If that, too, is unspecified, Promotions will fail if there is ever
+                                ambiguity regarding from which piece of Freight an artifact is to be
+                                sourced.
+                              properties:
+                                kind:
+                                  description: |-
+                                    Kind is the kind of resource from which Freight may have originated. At
+                                    present, this can only be "Warehouse".
+                                  enum:
+                                  - Warehouse
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name is the name of the resource of the kind indicated by the Kind field
+                                    from which Freight may originated.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
                           type: object
                         insecureSkipTLSVerify:
                           description: |-
@@ -366,6 +615,34 @@ spec:
                                       (without tag). This is a required field.
                                     minLength: 1
                                     type: string
+                                  origin:
+                                    description: |-
+                                      Origin disambiguates the origin from which artifacts used by this promotion
+                                      mechanism must have originated. This is especially useful in cases where a
+                                      Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                      and some of those each reference different versions of artifacts from the
+                                      same repository. This field is optional. When left unspecified, it will
+                                      implicitly inherit the value of the enclosing KustomizePromotionMechanism's
+                                      Origin field. If that, too, is unspecified, Promotions will fail if there
+                                      is ever ambiguity regarding from which piece of Freight an artifact is to
+                                      be sourced.
+                                    properties:
+                                      kind:
+                                        description: |-
+                                          Kind is the kind of resource from which Freight may have originated. At
+                                          present, this can only be "Warehouse".
+                                        enum:
+                                        - Warehouse
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name is the name of the resource of the kind indicated by the Kind field
+                                          from which Freight may originated.
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
                                   path:
                                     description: |-
                                       Path specifies a path in which the `kustomize edit set image` command
@@ -384,8 +661,64 @@ spec:
                                 type: object
                               minItems: 1
                               type: array
+                            origin:
+                              description: |-
+                                Origin disambiguates the origin from which artifacts used by this promotion
+                                mechanism must have originated. This is especially useful in cases where a
+                                Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                and some of those each reference different versions of artifacts from the
+                                same repository. This field is optional. When left unspecified, it will
+                                implicitly inherit the value of the enclosing GitRepoUpdate's Origin field.
+                                If that, too, is unspecified, Promotions will fail if there is ever
+                                ambiguity regarding from which piece of Freight an artifact is to be
+                                sourced.
+                              properties:
+                                kind:
+                                  description: |-
+                                    Kind is the kind of resource from which Freight may have originated. At
+                                    present, this can only be "Warehouse".
+                                  enum:
+                                  - Warehouse
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name is the name of the resource of the kind indicated by the Kind field
+                                    from which Freight may originated.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
                           required:
                           - images
+                          type: object
+                        origin:
+                          description: |-
+                            Origin disambiguates the origin from which artifacts used by this promotion
+                            mechanism must have originated. This is especially useful in cases where a
+                            Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                            and some of those each reference different versions of artifacts from the
+                            same repository. This field is optional. When left unspecified, the branch
+                            checked out by this promotion mechanism will be the one specified by the
+                            ReadBranch field. If that, too, is unspecified, the default branch of the
+                            repository will be checked out. Always provide a value for this field if
+                            wishing to check out a specific commit indicated by a piece of Freight.
+                          properties:
+                            kind:
+                              description: |-
+                                Kind is the kind of resource from which Freight may have originated. At
+                                present, this can only be "Warehouse".
+                              enum:
+                              - Warehouse
+                              type: string
+                            name:
+                              description: |-
+                                Name is the name of the resource of the kind indicated by the Kind field
+                                from which Freight may originated.
+                              type: string
+                          required:
+                          - kind
+                          - name
                           type: object
                         pullRequest:
                           description: PullRequest will generate a pull request instead
@@ -431,6 +764,34 @@ spec:
                                       (without tag). This is a required field.
                                     minLength: 1
                                     type: string
+                                  origin:
+                                    description: |-
+                                      Origin disambiguates the origin from which artifacts used by this promotion
+                                      mechanism must have originated. This is especially useful in cases where a
+                                      Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                      and some of those each reference different versions of artifacts from the
+                                      same repository. This field is optional. When left unspecified, it will
+                                      implicitly inherit the value of the enclosing
+                                      KargoRenderPromotionMechanism's Origin field. If that, too, is unspecified,
+                                      Promotions will fail if there is ever ambiguity regarding from which piece
+                                      of Freight an artifact is to be sourced.
+                                    properties:
+                                      kind:
+                                        description: |-
+                                          Kind is the kind of resource from which Freight may have originated. At
+                                          present, this can only be "Warehouse".
+                                        enum:
+                                        - Warehouse
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name is the name of the resource of the kind indicated by the Kind field
+                                          from which Freight may originated.
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
                                   useDigest:
                                     description: |-
                                       UseDigest specifies whether the image's digest should be used instead of
@@ -440,6 +801,34 @@ spec:
                                 - image
                                 type: object
                               type: array
+                            origin:
+                              description: |-
+                                Origin disambiguates the origin from which artifacts used by this promotion
+                                mechanism must have originated. This is especially useful in cases where a
+                                Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                                and some of those each reference different versions of artifacts from the
+                                same repository. This field is optional. When left unspecified, it will
+                                implicitly inherit the value of the enclosing GitRepoUpdate's Origin field.
+                                If that, too, is unspecified, Promotions will fail if there is ever
+                                ambiguity regarding from which piece of Freight an artifact is to be
+                                sourced.
+                              properties:
+                                kind:
+                                  description: |-
+                                    Kind is the kind of resource from which Freight may have originated. At
+                                    present, this can only be "Warehouse".
+                                  enum:
+                                  - Warehouse
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name is the name of the resource of the kind indicated by the Kind field
+                                    from which Freight may originated.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
                           type: object
                         repoURL:
                           description: RepoURL is the URL of the repository to update.
@@ -459,7 +848,96 @@ spec:
                       - writeBranch
                       type: object
                     type: array
+                  origin:
+                    description: |-
+                      Origin disambiguates the origin from which artifacts used by this promotion
+                      mechanism must have originated. This is especially useful in cases where a
+                      Stage may request Freight from multiples origins (e.g. multiple Warehouses)
+                      and some of those each reference different versions of artifacts from the
+                      same repository. This field is optional. Its value is overridable by
+                      child promotion mechanisms.
+                    properties:
+                      kind:
+                        description: |-
+                          Kind is the kind of resource from which Freight may have originated. At
+                          present, this can only be "Warehouse".
+                        enum:
+                        - Warehouse
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the resource of the kind indicated by the Kind field
+                          from which Freight may originated.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
                 type: object
+              requestedFreight:
+                description: |-
+                  RequestedFreight expresses the Stage's need for certain pieces of Freight,
+                  each having originated from a particular Warehouse. This list must be
+                  non-empty. In the common case, a Stage will request Freight having
+                  originated from just one specific Warehouse. In advanced cases, requesting
+                  Freight from multiple Warehouses provides a method of advancing new
+                  artifacts of different types through parallel pipelines at different
+                  speeds. This can be useful, for instance, if a Stage is home to multiple
+                  microservices that are independently versioned.
+                items:
+                  description: |-
+                    FreightRequest expresses a Stage's need for Freight having originated from a
+                    particular Warehouse.
+                  properties:
+                    origin:
+                      description: |-
+                        Origin specifies from where the requested Freight must have originated.
+                        This is a required field.
+                      properties:
+                        kind:
+                          description: |-
+                            Kind is the kind of resource from which Freight may have originated. At
+                            present, this can only be "Warehouse".
+                          enum:
+                          - Warehouse
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the resource of the kind indicated by the Kind field
+                            from which Freight may originated.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    sources:
+                      description: |-
+                        Sources describes where the requested Freight may be obtained from. This is
+                        a required field.
+                      properties:
+                        direct:
+                          description: |-
+                            Direct indicates the requested Freight may be obtained directly from the
+                            Warehouse from which it originated. If this field's value is false, then
+                            the value of the Stages field must be non-empty. i.e. Between the two
+                            fields, at least one source must be specified.
+                          type: boolean
+                        stages:
+                          description: |-
+                            Stages identifies other "upstream" Stages as potential sources of the
+                            requested Freight. If this field's value is empty, then the value of the
+                            Direct field must be true. i.e. Between the two fields, at least on source
+                            must be specified.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  required:
+                  - origin
+                  - sources
+                  type: object
+                minItems: 1
+                type: array
               shard:
                 description: |-
                   Shard is the name of the shard that this Stage belongs to. This is an
@@ -472,14 +950,20 @@ spec:
                 description: |-
                   Subscriptions describes the Stage's sources of Freight. This is a required
                   field.
+
+
+                  Deprecated: Use RequestedFreight instead.
                 properties:
                   upstreamStages:
                     description: |-
                       UpstreamStages identifies other Stages as potential sources of Freight
                       for this Stage. This field is mutually exclusive with the Repos field.
                     items:
-                      description: StageSubscription defines a subscription to Freight
-                        from another Stage.
+                      description: |-
+                        StageSubscription defines a subscription to Freight from another Stage.
+
+
+                        Deprecated: Use FreightRequest instead.
                       properties:
                         name:
                           description: Name specifies the name of a Stage.
@@ -554,6 +1038,7 @@ spec:
                     type: array
                 type: object
             required:
+            - requestedFreight
             - subscriptions
             type: object
           status:
@@ -564,6 +1049,9 @@ spec:
                 description: |-
                   CurrentFreight is a simplified representation of the Stage's current
                   Freight describing what is currently deployed to the Stage.
+
+
+                  Deprecated: Use the top item in the FreightHistory stack instead.
                 properties:
                   charts:
                     description: Charts describes specific versions of specific Helm
@@ -608,7 +1096,7 @@ spec:
                         healthCheckCommit:
                           description: |-
                             HealthCheckCommit is the ID of a specific commit. When specified,
-                            assessments of Stage health will used this value (instead of ID) when
+                            assessments of Stage health will use this value (instead of ID) when
                             determining if applicable sources of Argo CD Application resources
                             associated with the Stage are or are not synced to this commit. Note that
                             there are cases (as in that of Kargo Render being utilized as a promotion
@@ -670,14 +1158,37 @@ spec:
                       the contents of the Freight. i.e. Two pieces of Freight can be compared for
                       equality by comparing their Names.
                     type: string
+                  origin:
+                    description: Origin describes a kind of Freight in terms of its
+                      origin.
+                    properties:
+                      kind:
+                        description: |-
+                          Kind is the kind of resource from which Freight may have originated. At
+                          present, this can only be "Warehouse".
+                        enum:
+                        - Warehouse
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the resource of the kind indicated by the Kind field
+                          from which Freight may originated.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
                   verificationHistory:
                     description: |-
                       VerificationHistory is a stack of recent VerificationInfo. By default,
                       the last ten VerificationInfo are stored.
+
+
+                      Deprecated: Use FreightCollection.VerificationHistory instead.
                     items:
                       description: |-
-                        VerificationInfo contains information about the currently running
-                        Verification process.
+                        VerificationInfo contains the details of an instance of a Verification
+                        process.
                       properties:
                         actor:
                           description: |-
@@ -735,6 +1246,9 @@ spec:
                     description: |-
                       VerificationInfo is information about any verification process that was
                       associated with this Freight for this Stage.
+
+
+                      Deprecated: Use FreightCollection.VerificationHistory instead.
                     properties:
                       actor:
                         description: |-
@@ -788,8 +1302,11 @@ spec:
                         type: string
                     type: object
                   warehouse:
-                    description: Warehouse is the name of the Warehouse that created
-                      this Freight.
+                    description: |-
+                      Warehouse is the name of the Warehouse that created this Freight.
+
+
+                      Deprecated: Use the Origin instead.
                     type: string
                 type: object
               currentPromotion:
@@ -849,7 +1366,7 @@ spec:
                             healthCheckCommit:
                               description: |-
                                 HealthCheckCommit is the ID of a specific commit. When specified,
-                                assessments of Stage health will used this value (instead of ID) when
+                                assessments of Stage health will use this value (instead of ID) when
                                 determining if applicable sources of Argo CD Application resources
                                 associated with the Stage are or are not synced to this commit. Note that
                                 there are cases (as in that of Kargo Render being utilized as a promotion
@@ -911,14 +1428,37 @@ spec:
                           the contents of the Freight. i.e. Two pieces of Freight can be compared for
                           equality by comparing their Names.
                         type: string
+                      origin:
+                        description: Origin describes a kind of Freight in terms of
+                          its origin.
+                        properties:
+                          kind:
+                            description: |-
+                              Kind is the kind of resource from which Freight may have originated. At
+                              present, this can only be "Warehouse".
+                            enum:
+                            - Warehouse
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the resource of the kind indicated by the Kind field
+                              from which Freight may originated.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
                       verificationHistory:
                         description: |-
                           VerificationHistory is a stack of recent VerificationInfo. By default,
                           the last ten VerificationInfo are stored.
+
+
+                          Deprecated: Use FreightCollection.VerificationHistory instead.
                         items:
                           description: |-
-                            VerificationInfo contains information about the currently running
-                            Verification process.
+                            VerificationInfo contains the details of an instance of a Verification
+                            process.
                           properties:
                             actor:
                               description: |-
@@ -977,6 +1517,9 @@ spec:
                         description: |-
                           VerificationInfo is information about any verification process that was
                           associated with this Freight for this Stage.
+
+
+                          Deprecated: Use FreightCollection.VerificationHistory instead.
                         properties:
                           actor:
                             description: |-
@@ -1031,8 +1574,11 @@ spec:
                             type: string
                         type: object
                       warehouse:
-                        description: Warehouse is the name of the Warehouse that created
-                          this Freight.
+                        description: |-
+                          Warehouse is the name of the Warehouse that created this Freight.
+
+
+                          Deprecated: Use the Origin instead.
                         type: string
                     type: object
                   name:
@@ -1096,7 +1642,7 @@ spec:
                                 healthCheckCommit:
                                   description: |-
                                     HealthCheckCommit is the ID of a specific commit. When specified,
-                                    assessments of Stage health will used this value (instead of ID) when
+                                    assessments of Stage health will use this value (instead of ID) when
                                     determining if applicable sources of Argo CD Application resources
                                     associated with the Stage are or are not synced to this commit. Note that
                                     there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1158,14 +1704,37 @@ spec:
                               the contents of the Freight. i.e. Two pieces of Freight can be compared for
                               equality by comparing their Names.
                             type: string
+                          origin:
+                            description: Origin describes a kind of Freight in terms
+                              of its origin.
+                            properties:
+                              kind:
+                                description: |-
+                                  Kind is the kind of resource from which Freight may have originated. At
+                                  present, this can only be "Warehouse".
+                                enum:
+                                - Warehouse
+                                type: string
+                              name:
+                                description: |-
+                                  Name is the name of the resource of the kind indicated by the Kind field
+                                  from which Freight may originated.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
                           verificationHistory:
                             description: |-
                               VerificationHistory is a stack of recent VerificationInfo. By default,
                               the last ten VerificationInfo are stored.
+
+
+                              Deprecated: Use FreightCollection.VerificationHistory instead.
                             items:
                               description: |-
-                                VerificationInfo contains information about the currently running
-                                Verification process.
+                                VerificationInfo contains the details of an instance of a Verification
+                                process.
                               properties:
                                 actor:
                                   description: |-
@@ -1225,6 +1794,9 @@ spec:
                             description: |-
                               VerificationInfo is information about any verification process that was
                               associated with this Freight for this Stage.
+
+
+                              Deprecated: Use FreightCollection.VerificationHistory instead.
                             properties:
                               actor:
                                 description: |-
@@ -1280,9 +1852,365 @@ spec:
                                 type: string
                             type: object
                           warehouse:
-                            description: Warehouse is the name of the Warehouse that
-                              created this Freight.
+                            description: |-
+                              Warehouse is the name of the Warehouse that created this Freight.
+
+
+                              Deprecated: Use the Origin instead.
                             type: string
+                        type: object
+                      freightCollection:
+                        description: |-
+                          FreightCollection contains the details of the piece of Freight referenced
+                          by this Promotion as well as any additional Freight that is carried over
+                          from the target Stage's current state.
+                        properties:
+                          id:
+                            description: |-
+                              ID is a unique and deterministically calculated identifier for the
+                              FreightCollection. It is updated on each use of the UpdateOrPush method.
+                            type: string
+                          items:
+                            additionalProperties:
+                              description: |-
+                                FreightReference is a simplified representation of a piece of Freight -- not
+                                a root resource type.
+                              properties:
+                                charts:
+                                  description: Charts describes specific versions
+                                    of specific Helm charts.
+                                  items:
+                                    description: Chart describes a specific version
+                                      of a Helm chart.
+                                    properties:
+                                      name:
+                                        description: Name specifies the name of the
+                                          chart.
+                                        type: string
+                                      repoURL:
+                                        description: |-
+                                          RepoURL specifies the URL of a Helm chart repository. Classic chart
+                                          repositories (using HTTP/S) can contain differently named charts. When this
+                                          field points to such a repository, the Name field will specify the name of
+                                          the chart within the repository. In the case of a repository within an OCI
+                                          registry, the URL implicitly points to a specific chart and the Name field
+                                          will be empty.
+                                        type: string
+                                      version:
+                                        description: Version specifies a particular
+                                          version of the chart.
+                                        type: string
+                                    type: object
+                                  type: array
+                                commits:
+                                  description: Commits describes specific Git repository
+                                    commits.
+                                  items:
+                                    description: GitCommit describes a specific commit
+                                      from a specific Git repository.
+                                    properties:
+                                      author:
+                                        description: Author is the author of the commit.
+                                        type: string
+                                      branch:
+                                        description: Branch denotes the branch of
+                                          the repository where this commit was found.
+                                        type: string
+                                      committer:
+                                        description: Committer is the person who committed
+                                          the commit.
+                                        type: string
+                                      healthCheckCommit:
+                                        description: |-
+                                          HealthCheckCommit is the ID of a specific commit. When specified,
+                                          assessments of Stage health will use this value (instead of ID) when
+                                          determining if applicable sources of Argo CD Application resources
+                                          associated with the Stage are or are not synced to this commit. Note that
+                                          there are cases (as in that of Kargo Render being utilized as a promotion
+                                          mechanism) wherein the value of this field may differ from the commit ID
+                                          found in the ID field.
+                                        type: string
+                                      id:
+                                        description: |-
+                                          ID is the ID of a specific commit in the Git repository specified by
+                                          RepoURL.
+                                        type: string
+                                      message:
+                                        description: |-
+                                          Message is the message associated with the commit. At present, this only
+                                          contains the first line (subject) of the commit message.
+                                        type: string
+                                      repoURL:
+                                        description: RepoURL is the URL of a Git repository.
+                                        type: string
+                                      tag:
+                                        description: |-
+                                          Tag denotes a tag in the repository that matched selection criteria and
+                                          resolved to this commit.
+                                        type: string
+                                    type: object
+                                  type: array
+                                images:
+                                  description: Images describes specific versions
+                                    of specific container images.
+                                  items:
+                                    description: Image describes a specific version
+                                      of a container image.
+                                    properties:
+                                      digest:
+                                        description: |-
+                                          Digest identifies a specific version of the image in the repository
+                                          specified by RepoURL. This is a more precise identifier than Tag.
+                                        type: string
+                                      gitRepoURL:
+                                        description: |-
+                                          GitRepoURL specifies the URL of a Git repository that contains the source
+                                          code for the image repository referenced by the RepoURL field if Kargo was
+                                          able to infer it.
+                                        type: string
+                                      repoURL:
+                                        description: RepoURL describes the repository
+                                          in which the image can be found.
+                                        type: string
+                                      tag:
+                                        description: |-
+                                          Tag identifies a specific version of the image in the repository specified
+                                          by RepoURL.
+                                        type: string
+                                    type: object
+                                  type: array
+                                name:
+                                  description: |-
+                                    Name is system-assigned identifier that is derived deterministically from
+                                    the contents of the Freight. i.e. Two pieces of Freight can be compared for
+                                    equality by comparing their Names.
+                                  type: string
+                                origin:
+                                  description: Origin describes a kind of Freight
+                                    in terms of its origin.
+                                  properties:
+                                    kind:
+                                      description: |-
+                                        Kind is the kind of resource from which Freight may have originated. At
+                                        present, this can only be "Warehouse".
+                                      enum:
+                                      - Warehouse
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name is the name of the resource of the kind indicated by the Kind field
+                                        from which Freight may originated.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                verificationHistory:
+                                  description: |-
+                                    VerificationHistory is a stack of recent VerificationInfo. By default,
+                                    the last ten VerificationInfo are stored.
+
+
+                                    Deprecated: Use FreightCollection.VerificationHistory instead.
+                                  items:
+                                    description: |-
+                                      VerificationInfo contains the details of an instance of a Verification
+                                      process.
+                                    properties:
+                                      actor:
+                                        description: |-
+                                          Actor is the name of the entity that initiated or aborted the
+                                          Verification process.
+                                        type: string
+                                      analysisRun:
+                                        description: |-
+                                          AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                          the Verification process.
+                                        properties:
+                                          name:
+                                            description: Name is the name of the AnalysisRun.
+                                            type: string
+                                          namespace:
+                                            description: Namespace is the namespace
+                                              of the AnalysisRun.
+                                            type: string
+                                          phase:
+                                            description: Phase is the last observed
+                                              phase of the AnalysisRun referenced
+                                              by Name.
+                                            type: string
+                                        required:
+                                        - name
+                                        - namespace
+                                        - phase
+                                        type: object
+                                      finishTime:
+                                        description: FinishTime is the time at which
+                                          the Verification process finished.
+                                        format: date-time
+                                        type: string
+                                      id:
+                                        description: ID is the identifier of the Verification
+                                          process.
+                                        type: string
+                                      message:
+                                        description: |-
+                                          Message may contain additional information about why the verification
+                                          process is in its current phase.
+                                        type: string
+                                      phase:
+                                        description: |-
+                                          Phase describes the current phase of the Verification process. Generally,
+                                          this will be a reflection of the underlying AnalysisRun's phase, however,
+                                          there are exceptions to this, such as in the case where an AnalysisRun
+                                          cannot be launched successfully.
+                                        type: string
+                                      startTime:
+                                        description: StartTime is the time at which
+                                          the Verification process was started.
+                                        format: date-time
+                                        type: string
+                                    type: object
+                                  type: array
+                                verificationInfo:
+                                  description: |-
+                                    VerificationInfo is information about any verification process that was
+                                    associated with this Freight for this Stage.
+
+
+                                    Deprecated: Use FreightCollection.VerificationHistory instead.
+                                  properties:
+                                    actor:
+                                      description: |-
+                                        Actor is the name of the entity that initiated or aborted the
+                                        Verification process.
+                                      type: string
+                                    analysisRun:
+                                      description: |-
+                                        AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                        the Verification process.
+                                      properties:
+                                        name:
+                                          description: Name is the name of the AnalysisRun.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of the AnalysisRun.
+                                          type: string
+                                        phase:
+                                          description: Phase is the last observed
+                                            phase of the AnalysisRun referenced by
+                                            Name.
+                                          type: string
+                                      required:
+                                      - name
+                                      - namespace
+                                      - phase
+                                      type: object
+                                    finishTime:
+                                      description: FinishTime is the time at which
+                                        the Verification process finished.
+                                      format: date-time
+                                      type: string
+                                    id:
+                                      description: ID is the identifier of the Verification
+                                        process.
+                                      type: string
+                                    message:
+                                      description: |-
+                                        Message may contain additional information about why the verification
+                                        process is in its current phase.
+                                      type: string
+                                    phase:
+                                      description: |-
+                                        Phase describes the current phase of the Verification process. Generally,
+                                        this will be a reflection of the underlying AnalysisRun's phase, however,
+                                        there are exceptions to this, such as in the case where an AnalysisRun
+                                        cannot be launched successfully.
+                                      type: string
+                                    startTime:
+                                      description: StartTime is the time at which
+                                        the Verification process was started.
+                                      format: date-time
+                                      type: string
+                                  type: object
+                                warehouse:
+                                  description: |-
+                                    Warehouse is the name of the Warehouse that created this Freight.
+
+
+                                    Deprecated: Use the Origin instead.
+                                  type: string
+                              type: object
+                            description: |-
+                              Freight is a map of FreightReference objects, indexed by their Warehouse
+                              origin.
+                            type: object
+                          verificationHistory:
+                            description: |-
+                              VerificationHistory is a stack of recent VerificationInfo. By default,
+                              the last ten VerificationInfo are stored.
+                            items:
+                              description: |-
+                                VerificationInfo contains the details of an instance of a Verification
+                                process.
+                              properties:
+                                actor:
+                                  description: |-
+                                    Actor is the name of the entity that initiated or aborted the
+                                    Verification process.
+                                  type: string
+                                analysisRun:
+                                  description: |-
+                                    AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                    the Verification process.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the AnalysisRun.
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of the
+                                        AnalysisRun.
+                                      type: string
+                                    phase:
+                                      description: Phase is the last observed phase
+                                        of the AnalysisRun referenced by Name.
+                                      type: string
+                                  required:
+                                  - name
+                                  - namespace
+                                  - phase
+                                  type: object
+                                finishTime:
+                                  description: FinishTime is the time at which the
+                                    Verification process finished.
+                                  format: date-time
+                                  type: string
+                                id:
+                                  description: ID is the identifier of the Verification
+                                    process.
+                                  type: string
+                                message:
+                                  description: |-
+                                    Message may contain additional information about why the verification
+                                    process is in its current phase.
+                                  type: string
+                                phase:
+                                  description: |-
+                                    Phase describes the current phase of the Verification process. Generally,
+                                    this will be a reflection of the underlying AnalysisRun's phase, however,
+                                    there are exceptions to this, such as in the case where an AnalysisRun
+                                    cannot be launched successfully.
+                                  type: string
+                                startTime:
+                                  description: StartTime is the time at which the
+                                    Verification process was started.
+                                  format: date-time
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - id
                         type: object
                       lastHandledRefresh:
                         description: |-
@@ -1310,9 +2238,377 @@ spec:
                         type: string
                     type: object
                 required:
-                - freight
                 - name
                 type: object
+              freightHistory:
+                description: |-
+                  FreightHistory is a list of recent Freight selections that were deployed
+                  to the Stage. By default, the last ten Freight selections are stored.
+                  The first item in the list is the most recent Freight selection and
+                  currently deployed to the Stage, subsequent items are older selections.
+                items:
+                  description: |-
+                    FreightCollection is a collection of FreightReferences, each of which
+                    represents a piece of Freight that has been selected for deployment to a
+                    Stage.
+                  properties:
+                    id:
+                      description: |-
+                        ID is a unique and deterministically calculated identifier for the
+                        FreightCollection. It is updated on each use of the UpdateOrPush method.
+                      type: string
+                    items:
+                      additionalProperties:
+                        description: |-
+                          FreightReference is a simplified representation of a piece of Freight -- not
+                          a root resource type.
+                        properties:
+                          charts:
+                            description: Charts describes specific versions of specific
+                              Helm charts.
+                            items:
+                              description: Chart describes a specific version of a
+                                Helm chart.
+                              properties:
+                                name:
+                                  description: Name specifies the name of the chart.
+                                  type: string
+                                repoURL:
+                                  description: |-
+                                    RepoURL specifies the URL of a Helm chart repository. Classic chart
+                                    repositories (using HTTP/S) can contain differently named charts. When this
+                                    field points to such a repository, the Name field will specify the name of
+                                    the chart within the repository. In the case of a repository within an OCI
+                                    registry, the URL implicitly points to a specific chart and the Name field
+                                    will be empty.
+                                  type: string
+                                version:
+                                  description: Version specifies a particular version
+                                    of the chart.
+                                  type: string
+                              type: object
+                            type: array
+                          commits:
+                            description: Commits describes specific Git repository
+                              commits.
+                            items:
+                              description: GitCommit describes a specific commit from
+                                a specific Git repository.
+                              properties:
+                                author:
+                                  description: Author is the author of the commit.
+                                  type: string
+                                branch:
+                                  description: Branch denotes the branch of the repository
+                                    where this commit was found.
+                                  type: string
+                                committer:
+                                  description: Committer is the person who committed
+                                    the commit.
+                                  type: string
+                                healthCheckCommit:
+                                  description: |-
+                                    HealthCheckCommit is the ID of a specific commit. When specified,
+                                    assessments of Stage health will use this value (instead of ID) when
+                                    determining if applicable sources of Argo CD Application resources
+                                    associated with the Stage are or are not synced to this commit. Note that
+                                    there are cases (as in that of Kargo Render being utilized as a promotion
+                                    mechanism) wherein the value of this field may differ from the commit ID
+                                    found in the ID field.
+                                  type: string
+                                id:
+                                  description: |-
+                                    ID is the ID of a specific commit in the Git repository specified by
+                                    RepoURL.
+                                  type: string
+                                message:
+                                  description: |-
+                                    Message is the message associated with the commit. At present, this only
+                                    contains the first line (subject) of the commit message.
+                                  type: string
+                                repoURL:
+                                  description: RepoURL is the URL of a Git repository.
+                                  type: string
+                                tag:
+                                  description: |-
+                                    Tag denotes a tag in the repository that matched selection criteria and
+                                    resolved to this commit.
+                                  type: string
+                              type: object
+                            type: array
+                          images:
+                            description: Images describes specific versions of specific
+                              container images.
+                            items:
+                              description: Image describes a specific version of a
+                                container image.
+                              properties:
+                                digest:
+                                  description: |-
+                                    Digest identifies a specific version of the image in the repository
+                                    specified by RepoURL. This is a more precise identifier than Tag.
+                                  type: string
+                                gitRepoURL:
+                                  description: |-
+                                    GitRepoURL specifies the URL of a Git repository that contains the source
+                                    code for the image repository referenced by the RepoURL field if Kargo was
+                                    able to infer it.
+                                  type: string
+                                repoURL:
+                                  description: RepoURL describes the repository in
+                                    which the image can be found.
+                                  type: string
+                                tag:
+                                  description: |-
+                                    Tag identifies a specific version of the image in the repository specified
+                                    by RepoURL.
+                                  type: string
+                              type: object
+                            type: array
+                          name:
+                            description: |-
+                              Name is system-assigned identifier that is derived deterministically from
+                              the contents of the Freight. i.e. Two pieces of Freight can be compared for
+                              equality by comparing their Names.
+                            type: string
+                          origin:
+                            description: Origin describes a kind of Freight in terms
+                              of its origin.
+                            properties:
+                              kind:
+                                description: |-
+                                  Kind is the kind of resource from which Freight may have originated. At
+                                  present, this can only be "Warehouse".
+                                enum:
+                                - Warehouse
+                                type: string
+                              name:
+                                description: |-
+                                  Name is the name of the resource of the kind indicated by the Kind field
+                                  from which Freight may originated.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          verificationHistory:
+                            description: |-
+                              VerificationHistory is a stack of recent VerificationInfo. By default,
+                              the last ten VerificationInfo are stored.
+
+
+                              Deprecated: Use FreightCollection.VerificationHistory instead.
+                            items:
+                              description: |-
+                                VerificationInfo contains the details of an instance of a Verification
+                                process.
+                              properties:
+                                actor:
+                                  description: |-
+                                    Actor is the name of the entity that initiated or aborted the
+                                    Verification process.
+                                  type: string
+                                analysisRun:
+                                  description: |-
+                                    AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                    the Verification process.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the AnalysisRun.
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of the
+                                        AnalysisRun.
+                                      type: string
+                                    phase:
+                                      description: Phase is the last observed phase
+                                        of the AnalysisRun referenced by Name.
+                                      type: string
+                                  required:
+                                  - name
+                                  - namespace
+                                  - phase
+                                  type: object
+                                finishTime:
+                                  description: FinishTime is the time at which the
+                                    Verification process finished.
+                                  format: date-time
+                                  type: string
+                                id:
+                                  description: ID is the identifier of the Verification
+                                    process.
+                                  type: string
+                                message:
+                                  description: |-
+                                    Message may contain additional information about why the verification
+                                    process is in its current phase.
+                                  type: string
+                                phase:
+                                  description: |-
+                                    Phase describes the current phase of the Verification process. Generally,
+                                    this will be a reflection of the underlying AnalysisRun's phase, however,
+                                    there are exceptions to this, such as in the case where an AnalysisRun
+                                    cannot be launched successfully.
+                                  type: string
+                                startTime:
+                                  description: StartTime is the time at which the
+                                    Verification process was started.
+                                  format: date-time
+                                  type: string
+                              type: object
+                            type: array
+                          verificationInfo:
+                            description: |-
+                              VerificationInfo is information about any verification process that was
+                              associated with this Freight for this Stage.
+
+
+                              Deprecated: Use FreightCollection.VerificationHistory instead.
+                            properties:
+                              actor:
+                                description: |-
+                                  Actor is the name of the entity that initiated or aborted the
+                                  Verification process.
+                                type: string
+                              analysisRun:
+                                description: |-
+                                  AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                  the Verification process.
+                                properties:
+                                  name:
+                                    description: Name is the name of the AnalysisRun.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the namespace of the
+                                      AnalysisRun.
+                                    type: string
+                                  phase:
+                                    description: Phase is the last observed phase
+                                      of the AnalysisRun referenced by Name.
+                                    type: string
+                                required:
+                                - name
+                                - namespace
+                                - phase
+                                type: object
+                              finishTime:
+                                description: FinishTime is the time at which the Verification
+                                  process finished.
+                                format: date-time
+                                type: string
+                              id:
+                                description: ID is the identifier of the Verification
+                                  process.
+                                type: string
+                              message:
+                                description: |-
+                                  Message may contain additional information about why the verification
+                                  process is in its current phase.
+                                type: string
+                              phase:
+                                description: |-
+                                  Phase describes the current phase of the Verification process. Generally,
+                                  this will be a reflection of the underlying AnalysisRun's phase, however,
+                                  there are exceptions to this, such as in the case where an AnalysisRun
+                                  cannot be launched successfully.
+                                type: string
+                              startTime:
+                                description: StartTime is the time at which the Verification
+                                  process was started.
+                                format: date-time
+                                type: string
+                            type: object
+                          warehouse:
+                            description: |-
+                              Warehouse is the name of the Warehouse that created this Freight.
+
+
+                              Deprecated: Use the Origin instead.
+                            type: string
+                        type: object
+                      description: |-
+                        Freight is a map of FreightReference objects, indexed by their Warehouse
+                        origin.
+                      type: object
+                    verificationHistory:
+                      description: |-
+                        VerificationHistory is a stack of recent VerificationInfo. By default,
+                        the last ten VerificationInfo are stored.
+                      items:
+                        description: |-
+                          VerificationInfo contains the details of an instance of a Verification
+                          process.
+                        properties:
+                          actor:
+                            description: |-
+                              Actor is the name of the entity that initiated or aborted the
+                              Verification process.
+                            type: string
+                          analysisRun:
+                            description: |-
+                              AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                              the Verification process.
+                            properties:
+                              name:
+                                description: Name is the name of the AnalysisRun.
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the AnalysisRun.
+                                type: string
+                              phase:
+                                description: Phase is the last observed phase of the
+                                  AnalysisRun referenced by Name.
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            - phase
+                            type: object
+                          finishTime:
+                            description: FinishTime is the time at which the Verification
+                              process finished.
+                            format: date-time
+                            type: string
+                          id:
+                            description: ID is the identifier of the Verification
+                              process.
+                            type: string
+                          message:
+                            description: |-
+                              Message may contain additional information about why the verification
+                              process is in its current phase.
+                            type: string
+                          phase:
+                            description: |-
+                              Phase describes the current phase of the Verification process. Generally,
+                              this will be a reflection of the underlying AnalysisRun's phase, however,
+                              there are exceptions to this, such as in the case where an AnalysisRun
+                              cannot be launched successfully.
+                            type: string
+                          startTime:
+                            description: StartTime is the time at which the Verification
+                              process was started.
+                            format: date-time
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - id
+                  type: object
+                type: array
+              freightSummary:
+                description: |-
+                  FreightSummary is human-readable text maintained by the controller that
+                  summarizes what Freight is currently deployed to the Stage. For Stages that
+                  request a single piece of Freight AND the request has been fulfilled, this
+                  field will simply contain the name of the Freight. For Stages that request
+                  a single piece of Freight AND the request has NOT been fulfilled, or for
+                  Stages that request multiple pieces of Freight, this field will contain a
+                  summary of fulfilled/requested Freight. The existence of this field is a
+                  workaround for kubectl limitations so that this complex but valuable
+                  information can be displayed in a column in response to `kubectl get
+                  stages`.
+                type: string
               health:
                 description: Health is the Stage's last observed health.
                 properties:
@@ -1374,6 +2670,9 @@ spec:
                 description: |-
                   History is a stack of recent Freight. By default, the last ten Freight are
                   stored.
+
+
+                  Deprecated: Use the FreightHistory stack instead.
                 items:
                   description: |-
                     FreightReference is a simplified representation of a piece of Freight -- not
@@ -1424,7 +2723,7 @@ spec:
                           healthCheckCommit:
                             description: |-
                               HealthCheckCommit is the ID of a specific commit. When specified,
-                              assessments of Stage health will used this value (instead of ID) when
+                              assessments of Stage health will use this value (instead of ID) when
                               determining if applicable sources of Argo CD Application resources
                               associated with the Stage are or are not synced to this commit. Note that
                               there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1486,14 +2785,37 @@ spec:
                         the contents of the Freight. i.e. Two pieces of Freight can be compared for
                         equality by comparing their Names.
                       type: string
+                    origin:
+                      description: Origin describes a kind of Freight in terms of
+                        its origin.
+                      properties:
+                        kind:
+                          description: |-
+                            Kind is the kind of resource from which Freight may have originated. At
+                            present, this can only be "Warehouse".
+                          enum:
+                          - Warehouse
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the resource of the kind indicated by the Kind field
+                            from which Freight may originated.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
                     verificationHistory:
                       description: |-
                         VerificationHistory is a stack of recent VerificationInfo. By default,
                         the last ten VerificationInfo are stored.
+
+
+                        Deprecated: Use FreightCollection.VerificationHistory instead.
                       items:
                         description: |-
-                          VerificationInfo contains information about the currently running
-                          Verification process.
+                          VerificationInfo contains the details of an instance of a Verification
+                          process.
                         properties:
                           actor:
                             description: |-
@@ -1552,6 +2874,9 @@ spec:
                       description: |-
                         VerificationInfo is information about any verification process that was
                         associated with this Freight for this Stage.
+
+
+                        Deprecated: Use FreightCollection.VerificationHistory instead.
                       properties:
                         actor:
                           description: |-
@@ -1605,8 +2930,11 @@ spec:
                           type: string
                       type: object
                     warehouse:
-                      description: Warehouse is the name of the Warehouse that created
-                        this Freight.
+                      description: |-
+                        Warehouse is the name of the Warehouse that created this Freight.
+
+
+                        Deprecated: Use the Origin instead.
                       type: string
                   type: object
                 type: array
@@ -1672,7 +3000,7 @@ spec:
                             healthCheckCommit:
                               description: |-
                                 HealthCheckCommit is the ID of a specific commit. When specified,
-                                assessments of Stage health will used this value (instead of ID) when
+                                assessments of Stage health will use this value (instead of ID) when
                                 determining if applicable sources of Argo CD Application resources
                                 associated with the Stage are or are not synced to this commit. Note that
                                 there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1734,14 +3062,37 @@ spec:
                           the contents of the Freight. i.e. Two pieces of Freight can be compared for
                           equality by comparing their Names.
                         type: string
+                      origin:
+                        description: Origin describes a kind of Freight in terms of
+                          its origin.
+                        properties:
+                          kind:
+                            description: |-
+                              Kind is the kind of resource from which Freight may have originated. At
+                              present, this can only be "Warehouse".
+                            enum:
+                            - Warehouse
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the resource of the kind indicated by the Kind field
+                              from which Freight may originated.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
                       verificationHistory:
                         description: |-
                           VerificationHistory is a stack of recent VerificationInfo. By default,
                           the last ten VerificationInfo are stored.
+
+
+                          Deprecated: Use FreightCollection.VerificationHistory instead.
                         items:
                           description: |-
-                            VerificationInfo contains information about the currently running
-                            Verification process.
+                            VerificationInfo contains the details of an instance of a Verification
+                            process.
                           properties:
                             actor:
                               description: |-
@@ -1800,6 +3151,9 @@ spec:
                         description: |-
                           VerificationInfo is information about any verification process that was
                           associated with this Freight for this Stage.
+
+
+                          Deprecated: Use FreightCollection.VerificationHistory instead.
                         properties:
                           actor:
                             description: |-
@@ -1854,8 +3208,11 @@ spec:
                             type: string
                         type: object
                       warehouse:
-                        description: Warehouse is the name of the Warehouse that created
-                          this Freight.
+                        description: |-
+                          Warehouse is the name of the Warehouse that created this Freight.
+
+
+                          Deprecated: Use the Origin instead.
                         type: string
                     type: object
                   name:
@@ -1919,7 +3276,7 @@ spec:
                                 healthCheckCommit:
                                   description: |-
                                     HealthCheckCommit is the ID of a specific commit. When specified,
-                                    assessments of Stage health will used this value (instead of ID) when
+                                    assessments of Stage health will use this value (instead of ID) when
                                     determining if applicable sources of Argo CD Application resources
                                     associated with the Stage are or are not synced to this commit. Note that
                                     there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1981,14 +3338,37 @@ spec:
                               the contents of the Freight. i.e. Two pieces of Freight can be compared for
                               equality by comparing their Names.
                             type: string
+                          origin:
+                            description: Origin describes a kind of Freight in terms
+                              of its origin.
+                            properties:
+                              kind:
+                                description: |-
+                                  Kind is the kind of resource from which Freight may have originated. At
+                                  present, this can only be "Warehouse".
+                                enum:
+                                - Warehouse
+                                type: string
+                              name:
+                                description: |-
+                                  Name is the name of the resource of the kind indicated by the Kind field
+                                  from which Freight may originated.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
                           verificationHistory:
                             description: |-
                               VerificationHistory is a stack of recent VerificationInfo. By default,
                               the last ten VerificationInfo are stored.
+
+
+                              Deprecated: Use FreightCollection.VerificationHistory instead.
                             items:
                               description: |-
-                                VerificationInfo contains information about the currently running
-                                Verification process.
+                                VerificationInfo contains the details of an instance of a Verification
+                                process.
                               properties:
                                 actor:
                                   description: |-
@@ -2048,6 +3428,9 @@ spec:
                             description: |-
                               VerificationInfo is information about any verification process that was
                               associated with this Freight for this Stage.
+
+
+                              Deprecated: Use FreightCollection.VerificationHistory instead.
                             properties:
                               actor:
                                 description: |-
@@ -2103,9 +3486,365 @@ spec:
                                 type: string
                             type: object
                           warehouse:
-                            description: Warehouse is the name of the Warehouse that
-                              created this Freight.
+                            description: |-
+                              Warehouse is the name of the Warehouse that created this Freight.
+
+
+                              Deprecated: Use the Origin instead.
                             type: string
+                        type: object
+                      freightCollection:
+                        description: |-
+                          FreightCollection contains the details of the piece of Freight referenced
+                          by this Promotion as well as any additional Freight that is carried over
+                          from the target Stage's current state.
+                        properties:
+                          id:
+                            description: |-
+                              ID is a unique and deterministically calculated identifier for the
+                              FreightCollection. It is updated on each use of the UpdateOrPush method.
+                            type: string
+                          items:
+                            additionalProperties:
+                              description: |-
+                                FreightReference is a simplified representation of a piece of Freight -- not
+                                a root resource type.
+                              properties:
+                                charts:
+                                  description: Charts describes specific versions
+                                    of specific Helm charts.
+                                  items:
+                                    description: Chart describes a specific version
+                                      of a Helm chart.
+                                    properties:
+                                      name:
+                                        description: Name specifies the name of the
+                                          chart.
+                                        type: string
+                                      repoURL:
+                                        description: |-
+                                          RepoURL specifies the URL of a Helm chart repository. Classic chart
+                                          repositories (using HTTP/S) can contain differently named charts. When this
+                                          field points to such a repository, the Name field will specify the name of
+                                          the chart within the repository. In the case of a repository within an OCI
+                                          registry, the URL implicitly points to a specific chart and the Name field
+                                          will be empty.
+                                        type: string
+                                      version:
+                                        description: Version specifies a particular
+                                          version of the chart.
+                                        type: string
+                                    type: object
+                                  type: array
+                                commits:
+                                  description: Commits describes specific Git repository
+                                    commits.
+                                  items:
+                                    description: GitCommit describes a specific commit
+                                      from a specific Git repository.
+                                    properties:
+                                      author:
+                                        description: Author is the author of the commit.
+                                        type: string
+                                      branch:
+                                        description: Branch denotes the branch of
+                                          the repository where this commit was found.
+                                        type: string
+                                      committer:
+                                        description: Committer is the person who committed
+                                          the commit.
+                                        type: string
+                                      healthCheckCommit:
+                                        description: |-
+                                          HealthCheckCommit is the ID of a specific commit. When specified,
+                                          assessments of Stage health will use this value (instead of ID) when
+                                          determining if applicable sources of Argo CD Application resources
+                                          associated with the Stage are or are not synced to this commit. Note that
+                                          there are cases (as in that of Kargo Render being utilized as a promotion
+                                          mechanism) wherein the value of this field may differ from the commit ID
+                                          found in the ID field.
+                                        type: string
+                                      id:
+                                        description: |-
+                                          ID is the ID of a specific commit in the Git repository specified by
+                                          RepoURL.
+                                        type: string
+                                      message:
+                                        description: |-
+                                          Message is the message associated with the commit. At present, this only
+                                          contains the first line (subject) of the commit message.
+                                        type: string
+                                      repoURL:
+                                        description: RepoURL is the URL of a Git repository.
+                                        type: string
+                                      tag:
+                                        description: |-
+                                          Tag denotes a tag in the repository that matched selection criteria and
+                                          resolved to this commit.
+                                        type: string
+                                    type: object
+                                  type: array
+                                images:
+                                  description: Images describes specific versions
+                                    of specific container images.
+                                  items:
+                                    description: Image describes a specific version
+                                      of a container image.
+                                    properties:
+                                      digest:
+                                        description: |-
+                                          Digest identifies a specific version of the image in the repository
+                                          specified by RepoURL. This is a more precise identifier than Tag.
+                                        type: string
+                                      gitRepoURL:
+                                        description: |-
+                                          GitRepoURL specifies the URL of a Git repository that contains the source
+                                          code for the image repository referenced by the RepoURL field if Kargo was
+                                          able to infer it.
+                                        type: string
+                                      repoURL:
+                                        description: RepoURL describes the repository
+                                          in which the image can be found.
+                                        type: string
+                                      tag:
+                                        description: |-
+                                          Tag identifies a specific version of the image in the repository specified
+                                          by RepoURL.
+                                        type: string
+                                    type: object
+                                  type: array
+                                name:
+                                  description: |-
+                                    Name is system-assigned identifier that is derived deterministically from
+                                    the contents of the Freight. i.e. Two pieces of Freight can be compared for
+                                    equality by comparing their Names.
+                                  type: string
+                                origin:
+                                  description: Origin describes a kind of Freight
+                                    in terms of its origin.
+                                  properties:
+                                    kind:
+                                      description: |-
+                                        Kind is the kind of resource from which Freight may have originated. At
+                                        present, this can only be "Warehouse".
+                                      enum:
+                                      - Warehouse
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name is the name of the resource of the kind indicated by the Kind field
+                                        from which Freight may originated.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                verificationHistory:
+                                  description: |-
+                                    VerificationHistory is a stack of recent VerificationInfo. By default,
+                                    the last ten VerificationInfo are stored.
+
+
+                                    Deprecated: Use FreightCollection.VerificationHistory instead.
+                                  items:
+                                    description: |-
+                                      VerificationInfo contains the details of an instance of a Verification
+                                      process.
+                                    properties:
+                                      actor:
+                                        description: |-
+                                          Actor is the name of the entity that initiated or aborted the
+                                          Verification process.
+                                        type: string
+                                      analysisRun:
+                                        description: |-
+                                          AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                          the Verification process.
+                                        properties:
+                                          name:
+                                            description: Name is the name of the AnalysisRun.
+                                            type: string
+                                          namespace:
+                                            description: Namespace is the namespace
+                                              of the AnalysisRun.
+                                            type: string
+                                          phase:
+                                            description: Phase is the last observed
+                                              phase of the AnalysisRun referenced
+                                              by Name.
+                                            type: string
+                                        required:
+                                        - name
+                                        - namespace
+                                        - phase
+                                        type: object
+                                      finishTime:
+                                        description: FinishTime is the time at which
+                                          the Verification process finished.
+                                        format: date-time
+                                        type: string
+                                      id:
+                                        description: ID is the identifier of the Verification
+                                          process.
+                                        type: string
+                                      message:
+                                        description: |-
+                                          Message may contain additional information about why the verification
+                                          process is in its current phase.
+                                        type: string
+                                      phase:
+                                        description: |-
+                                          Phase describes the current phase of the Verification process. Generally,
+                                          this will be a reflection of the underlying AnalysisRun's phase, however,
+                                          there are exceptions to this, such as in the case where an AnalysisRun
+                                          cannot be launched successfully.
+                                        type: string
+                                      startTime:
+                                        description: StartTime is the time at which
+                                          the Verification process was started.
+                                        format: date-time
+                                        type: string
+                                    type: object
+                                  type: array
+                                verificationInfo:
+                                  description: |-
+                                    VerificationInfo is information about any verification process that was
+                                    associated with this Freight for this Stage.
+
+
+                                    Deprecated: Use FreightCollection.VerificationHistory instead.
+                                  properties:
+                                    actor:
+                                      description: |-
+                                        Actor is the name of the entity that initiated or aborted the
+                                        Verification process.
+                                      type: string
+                                    analysisRun:
+                                      description: |-
+                                        AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                        the Verification process.
+                                      properties:
+                                        name:
+                                          description: Name is the name of the AnalysisRun.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of the AnalysisRun.
+                                          type: string
+                                        phase:
+                                          description: Phase is the last observed
+                                            phase of the AnalysisRun referenced by
+                                            Name.
+                                          type: string
+                                      required:
+                                      - name
+                                      - namespace
+                                      - phase
+                                      type: object
+                                    finishTime:
+                                      description: FinishTime is the time at which
+                                        the Verification process finished.
+                                      format: date-time
+                                      type: string
+                                    id:
+                                      description: ID is the identifier of the Verification
+                                        process.
+                                      type: string
+                                    message:
+                                      description: |-
+                                        Message may contain additional information about why the verification
+                                        process is in its current phase.
+                                      type: string
+                                    phase:
+                                      description: |-
+                                        Phase describes the current phase of the Verification process. Generally,
+                                        this will be a reflection of the underlying AnalysisRun's phase, however,
+                                        there are exceptions to this, such as in the case where an AnalysisRun
+                                        cannot be launched successfully.
+                                      type: string
+                                    startTime:
+                                      description: StartTime is the time at which
+                                        the Verification process was started.
+                                      format: date-time
+                                      type: string
+                                  type: object
+                                warehouse:
+                                  description: |-
+                                    Warehouse is the name of the Warehouse that created this Freight.
+
+
+                                    Deprecated: Use the Origin instead.
+                                  type: string
+                              type: object
+                            description: |-
+                              Freight is a map of FreightReference objects, indexed by their Warehouse
+                              origin.
+                            type: object
+                          verificationHistory:
+                            description: |-
+                              VerificationHistory is a stack of recent VerificationInfo. By default,
+                              the last ten VerificationInfo are stored.
+                            items:
+                              description: |-
+                                VerificationInfo contains the details of an instance of a Verification
+                                process.
+                              properties:
+                                actor:
+                                  description: |-
+                                    Actor is the name of the entity that initiated or aborted the
+                                    Verification process.
+                                  type: string
+                                analysisRun:
+                                  description: |-
+                                    AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements
+                                    the Verification process.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the AnalysisRun.
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of the
+                                        AnalysisRun.
+                                      type: string
+                                    phase:
+                                      description: Phase is the last observed phase
+                                        of the AnalysisRun referenced by Name.
+                                      type: string
+                                  required:
+                                  - name
+                                  - namespace
+                                  - phase
+                                  type: object
+                                finishTime:
+                                  description: FinishTime is the time at which the
+                                    Verification process finished.
+                                  format: date-time
+                                  type: string
+                                id:
+                                  description: ID is the identifier of the Verification
+                                    process.
+                                  type: string
+                                message:
+                                  description: |-
+                                    Message may contain additional information about why the verification
+                                    process is in its current phase.
+                                  type: string
+                                phase:
+                                  description: |-
+                                    Phase describes the current phase of the Verification process. Generally,
+                                    this will be a reflection of the underlying AnalysisRun's phase, however,
+                                    there are exceptions to this, such as in the case where an AnalysisRun
+                                    cannot be launched successfully.
+                                  type: string
+                                startTime:
+                                  description: StartTime is the time at which the
+                                    Verification process was started.
+                                  format: date-time
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - id
                         type: object
                       lastHandledRefresh:
                         description: |-
@@ -2133,7 +3872,6 @@ spec:
                         type: string
                     type: object
                 required:
-                - freight
                 - name
                 type: object
               message:

--- a/master-standalone-strict/applicationset-argoproj-v1alpha1.json
+++ b/master-standalone-strict/applicationset-argoproj-v1alpha1.json
@@ -8318,6 +8318,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 },
@@ -8429,6 +8447,21 @@
                               "properties": {
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "insecure": {
                                   "type": "boolean"
@@ -9493,6 +9526,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 }
@@ -9613,6 +9664,21 @@
                                 },
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "group": {
                                   "type": "string"
@@ -16115,6 +16181,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 },
@@ -16226,6 +16310,21 @@
                               "properties": {
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "insecure": {
                                   "type": "boolean"
@@ -17290,6 +17389,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 }
@@ -17410,6 +17527,21 @@
                                 },
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "group": {
                                   "type": "string"
@@ -20296,6 +20428,24 @@
                         ],
                         "type": "object"
                       },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
                       "project": {
                         "type": "string"
                       },
@@ -20407,6 +20557,21 @@
                     "properties": {
                       "api": {
                         "type": "string"
+                      },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
                       },
                       "insecure": {
                         "type": "boolean"
@@ -21471,6 +21636,24 @@
                         ],
                         "type": "object"
                       },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
                       "project": {
                         "type": "string"
                       }
@@ -21591,6 +21774,21 @@
                       },
                       "api": {
                         "type": "string"
+                      },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
                       },
                       "group": {
                         "type": "string"

--- a/master-standalone-strict/clustersecretstore-external-secrets-v1beta1.json
+++ b/master-standalone-strict/clustersecretstore-external-secrets-v1beta1.json
@@ -3025,6 +3025,13 @@
                   "description": "ForwardInconsistent tells Vault to forward read-after-write requests to the Vault\nleader instead of simply retrying within a loop. This can increase performance if\nthe option is enabled serverside.\nhttps://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header",
                   "type": "boolean"
                 },
+                "headers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Headers to be added in Vault request",
+                  "type": "object"
+                },
                 "namespace": {
                   "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows\nVault environments to support Secure Multi-tenancy. e.g: \"ns1\".\nMore about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
                   "type": "string"

--- a/master-standalone-strict/destinationrule-networking-v1.json
+++ b/master-standalone-strict/destinationrule-networking-v1.json
@@ -292,13 +292,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -757,13 +751,7 @@
                                     },
                                     "ttl": {
                                       "description": "Lifetime of the cookie.",
-                                      "type": "string",
-                                      "x-kubernetes-validations": [
-                                        {
-                                          "message": "must be a valid duration greater than 1ms",
-                                          "rule": "duration(self) >= duration('1ms')"
-                                        }
-                                      ]
+                                      "type": "string"
                                     }
                                   },
                                   "required": [
@@ -1395,13 +1383,7 @@
                         },
                         "ttl": {
                           "description": "Lifetime of the cookie.",
-                          "type": "string",
-                          "x-kubernetes-validations": [
-                            {
-                              "message": "must be a valid duration greater than 1ms",
-                              "rule": "duration(self) >= duration('1ms')"
-                            }
-                          ]
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -1867,13 +1849,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [

--- a/master-standalone-strict/destinationrule-networking-v1alpha3.json
+++ b/master-standalone-strict/destinationrule-networking-v1alpha3.json
@@ -292,13 +292,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -757,13 +751,7 @@
                                     },
                                     "ttl": {
                                       "description": "Lifetime of the cookie.",
-                                      "type": "string",
-                                      "x-kubernetes-validations": [
-                                        {
-                                          "message": "must be a valid duration greater than 1ms",
-                                          "rule": "duration(self) >= duration('1ms')"
-                                        }
-                                      ]
+                                      "type": "string"
                                     }
                                   },
                                   "required": [
@@ -1395,13 +1383,7 @@
                         },
                         "ttl": {
                           "description": "Lifetime of the cookie.",
-                          "type": "string",
-                          "x-kubernetes-validations": [
-                            {
-                              "message": "must be a valid duration greater than 1ms",
-                              "rule": "duration(self) >= duration('1ms')"
-                            }
-                          ]
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -1867,13 +1849,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [

--- a/master-standalone-strict/destinationrule-networking-v1beta1.json
+++ b/master-standalone-strict/destinationrule-networking-v1beta1.json
@@ -292,13 +292,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -757,13 +751,7 @@
                                     },
                                     "ttl": {
                                       "description": "Lifetime of the cookie.",
-                                      "type": "string",
-                                      "x-kubernetes-validations": [
-                                        {
-                                          "message": "must be a valid duration greater than 1ms",
-                                          "rule": "duration(self) >= duration('1ms')"
-                                        }
-                                      ]
+                                      "type": "string"
                                     }
                                   },
                                   "required": [
@@ -1395,13 +1383,7 @@
                         },
                         "ttl": {
                           "description": "Lifetime of the cookie.",
-                          "type": "string",
-                          "x-kubernetes-validations": [
-                            {
-                              "message": "must be a valid duration greater than 1ms",
-                              "rule": "duration(self) >= duration('1ms')"
-                            }
-                          ]
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -1867,13 +1849,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [

--- a/master-standalone-strict/freight-kargo-v1alpha1.json
+++ b/master-standalone-strict/freight-kargo-v1alpha1.json
@@ -49,7 +49,7 @@
             "type": "string"
           },
           "healthCheckCommit": {
-            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
             "type": "string"
           },
           "id": {
@@ -106,6 +106,27 @@
     "metadata": {
       "type": "object"
     },
+    "origin": {
+      "description": "Origin describes a kind of Freight in terms of its origin.",
+      "properties": {
+        "kind": {
+          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+          "enum": [
+            "Warehouse"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
     "status": {
       "description": "Status describes the current status of this Freight.",
       "properties": {
@@ -129,7 +150,7 @@
       "type": "object"
     },
     "warehouse": {
-      "description": "Warehouse is the name of the Warehouse that created this Freight. This is a\nrequired field. TODO: It is not clear yet how this field should be set in\nthe case of user-defined Freight.",
+      "description": "Warehouse is the name of the Warehouse that created this Freight. This is a\nrequired field. TODO: It is not clear yet how this field should be set in\nthe case of user-defined Freight.\n\n\nDeprecated: Use Origin instead.",
       "type": "string"
     },
     "spec": null

--- a/master-standalone-strict/ingressclassparams-elbv2-v1beta1.json
+++ b/master-standalone-strict/ingressclassparams-elbv2-v1beta1.json
@@ -2,11 +2,11 @@
   "description": "IngressClassParams is the Schema for the IngressClassParams API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -15,6 +15,13 @@
     "spec": {
       "description": "IngressClassParamsSpec defines the desired state of IngressClassParams",
       "properties": {
+        "certificateArn": {
+          "description": "CertificateArn specifies the ARN of the certificates for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "group": {
           "description": "Group defines the IngressGroup for all Ingresses that belong to IngressClass with this IngressClassParams.",
           "properties": {
@@ -29,11 +36,19 @@
           "type": "object",
           "additionalProperties": false
         },
+        "inboundCIDRs": {
+          "description": "InboundCIDRs specifies the CIDRs that are allowed to access the Ingresses that belong to IngressClass with this IngressClassParams.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "ipAddressType": {
           "description": "IPAddressType defines the ip address type for all Ingresses that belong to IngressClass with this IngressClassParams.",
           "enum": [
             "ipv4",
-            "dualstack"
+            "dualstack",
+            "dualstack-without-public-ipv4"
           ],
           "type": "string"
         },
@@ -60,27 +75,28 @@
           "type": "array"
         },
         "namespaceSelector": {
-          "description": "NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams. * if absent or present but empty, it selects all namespaces.",
+          "description": "NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams.\n* if absent or present but empty, it selects all namespaces.",
           "properties": {
             "matchExpressions": {
               "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
                     "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "required": [
@@ -89,17 +105,19 @@
                 ],
                 "type": "object"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "matchLabels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
           "type": "object",
+          "x-kubernetes-map-type": "atomic",
           "additionalProperties": false
         },
         "scheme": {
@@ -109,6 +127,37 @@
             "internet-facing"
           ],
           "type": "string"
+        },
+        "sslPolicy": {
+          "description": "SSLPolicy specifies the SSL Policy for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "type": "string"
+        },
+        "subnets": {
+          "description": "Subnets defines the subnets for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "properties": {
+            "ids": {
+              "description": "IDs specify the resource IDs of subnets. Exactly one of this or `tags` must be specified.",
+              "items": {
+                "description": "SubnetID specifies a subnet ID.",
+                "pattern": "subnet-[0-9a-f]+",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "tags": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "Tags specifies subnets in the load balancer's VPC where each\ntag specified in the map key contains one of the values in the corresponding\nvalue list.\nExactly one of this or `ids` must be specified.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "tags": {
           "description": "Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.",

--- a/master-standalone-strict/promotion-kargo-v1alpha1.json
+++ b/master-standalone-strict/promotion-kargo-v1alpha1.json
@@ -85,7 +85,7 @@
                     "type": "string"
                   },
                   "healthCheckCommit": {
-                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                     "type": "string"
                   },
                   "id": {
@@ -139,10 +139,31 @@
               "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
               "type": "string"
             },
+            "origin": {
+              "description": "Origin describes a kind of Freight in terms of its origin.",
+              "properties": {
+                "kind": {
+                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                  "enum": [
+                    "Warehouse"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object"
+            },
             "verificationHistory": {
-              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "items": {
-                "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                 "properties": {
                   "actor": {
                     "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -199,7 +220,7 @@
               "type": "array"
             },
             "verificationInfo": {
-              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "properties": {
                 "actor": {
                   "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -254,10 +275,325 @@
               "type": "object"
             },
             "warehouse": {
-              "description": "Warehouse is the name of the Warehouse that created this Freight.",
+              "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
               "type": "string"
             }
           },
+          "type": "object"
+        },
+        "freightCollection": {
+          "description": "FreightCollection contains the details of the piece of Freight referenced\nby this Promotion as well as any additional Freight that is carried over\nfrom the target Stage's current state.",
+          "properties": {
+            "id": {
+              "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+              "type": "string"
+            },
+            "items": {
+              "additionalProperties": {
+                "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                "properties": {
+                  "charts": {
+                    "description": "Charts describes specific versions of specific Helm charts.",
+                    "items": {
+                      "description": "Chart describes a specific version of a Helm chart.",
+                      "properties": {
+                        "name": {
+                          "description": "Name specifies the name of the chart.",
+                          "type": "string"
+                        },
+                        "repoURL": {
+                          "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version specifies a particular version of the chart.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "commits": {
+                    "description": "Commits describes specific Git repository commits.",
+                    "items": {
+                      "description": "GitCommit describes a specific commit from a specific Git repository.",
+                      "properties": {
+                        "author": {
+                          "description": "Author is the author of the commit.",
+                          "type": "string"
+                        },
+                        "branch": {
+                          "description": "Branch denotes the branch of the repository where this commit was found.",
+                          "type": "string"
+                        },
+                        "committer": {
+                          "description": "Committer is the person who committed the commit.",
+                          "type": "string"
+                        },
+                        "healthCheckCommit": {
+                          "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                          "type": "string"
+                        },
+                        "repoURL": {
+                          "description": "RepoURL is the URL of a Git repository.",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "images": {
+                    "description": "Images describes specific versions of specific container images.",
+                    "items": {
+                      "description": "Image describes a specific version of a container image.",
+                      "properties": {
+                        "digest": {
+                          "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                          "type": "string"
+                        },
+                        "gitRepoURL": {
+                          "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                          "type": "string"
+                        },
+                        "repoURL": {
+                          "description": "RepoURL describes the repository in which the image can be found.",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                    "type": "string"
+                  },
+                  "origin": {
+                    "description": "Origin describes a kind of Freight in terms of its origin.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                        "enum": [
+                          "Warehouse"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "verificationHistory": {
+                    "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                    "items": {
+                      "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                      "properties": {
+                        "actor": {
+                          "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                          "type": "string"
+                        },
+                        "analysisRun": {
+                          "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "phase": {
+                              "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "namespace",
+                            "phase"
+                          ],
+                          "type": "object"
+                        },
+                        "finishTime": {
+                          "description": "FinishTime is the time at which the Verification process finished.",
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the identifier of the Verification process.",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                          "type": "string"
+                        },
+                        "phase": {
+                          "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                          "type": "string"
+                        },
+                        "startTime": {
+                          "description": "StartTime is the time at which the Verification process was started.",
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "verificationInfo": {
+                    "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                    "properties": {
+                      "actor": {
+                        "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                        "type": "string"
+                      },
+                      "analysisRun": {
+                        "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the AnalysisRun.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace is the namespace of the AnalysisRun.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "namespace",
+                          "phase"
+                        ],
+                        "type": "object"
+                      },
+                      "finishTime": {
+                        "description": "FinishTime is the time at which the Verification process finished.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "ID is the identifier of the Verification process.",
+                        "type": "string"
+                      },
+                      "message": {
+                        "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                        "type": "string"
+                      },
+                      "phase": {
+                        "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                        "type": "string"
+                      },
+                      "startTime": {
+                        "description": "StartTime is the time at which the Verification process was started.",
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "warehouse": {
+                    "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+              "type": "object"
+            },
+            "verificationHistory": {
+              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+              "items": {
+                "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                "properties": {
+                  "actor": {
+                    "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                    "type": "string"
+                  },
+                  "analysisRun": {
+                    "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the name of the AnalysisRun.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace is the namespace of the AnalysisRun.",
+                        "type": "string"
+                      },
+                      "phase": {
+                        "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "namespace",
+                      "phase"
+                    ],
+                    "type": "object"
+                  },
+                  "finishTime": {
+                    "description": "FinishTime is the time at which the Verification process finished.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID is the identifier of the Verification process.",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                    "type": "string"
+                  },
+                  "phase": {
+                    "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "StartTime is the time at which the Verification process was started.",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
           "type": "object"
         },
         "lastHandledRefresh": {

--- a/master-standalone-strict/secretstore-external-secrets-v1beta1.json
+++ b/master-standalone-strict/secretstore-external-secrets-v1beta1.json
@@ -3025,6 +3025,13 @@
                   "description": "ForwardInconsistent tells Vault to forward read-after-write requests to the Vault\nleader instead of simply retrying within a loop. This can increase performance if\nthe option is enabled serverside.\nhttps://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header",
                   "type": "boolean"
                 },
+                "headers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Headers to be added in Vault request",
+                  "type": "object"
+                },
                 "namespace": {
                   "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows\nVault environments to support Secure Multi-tenancy. e.g: \"ns1\".\nMore about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
                   "type": "string"

--- a/master-standalone-strict/serviceentry-networking-v1.json
+++ b/master-standalone-strict/serviceentry-networking-v1.json
@@ -16,34 +16,62 @@
             "properties": {
               "address": {
                 "description": "Address associated with the network endpoint without the port.",
-                "type": "string"
+                "maxLength": 256,
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "UDS must be an absolute path or abstract socket",
+                    "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                  },
+                  {
+                    "message": "UDS may not be a dir",
+                    "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                  }
+                ]
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "One or more labels associated with the endpoint.",
+                "maxProperties": 256,
                 "type": "object"
               },
               "locality": {
                 "description": "The locality associated with the endpoint.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "network": {
                 "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "ports": {
                 "additionalProperties": {
                   "maximum": 4294967295,
                   "minimum": 0,
-                  "type": "integer"
+                  "type": "integer",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 },
                 "description": "Set of ports associated with the endpoint.",
-                "type": "object"
+                "maxProperties": 128,
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port name must be valid",
+                    "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                  }
+                ]
               },
               "serviceAccount": {
                 "description": "The service account associated with the workload if a sidecar is present in the workload.",
+                "maxLength": 253,
                 "type": "string"
               },
               "weight": {
@@ -53,8 +81,19 @@
                 "type": "integer"
               }
             },
-            "type": "object"
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "Address is required",
+                "rule": "has(self.address) || has(self.network)"
+              },
+              {
+                "message": "UDS may not include ports",
+                "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+              }
+            ]
           },
+          "maxItems": 4096,
           "type": "array"
         },
         "exportTo": {

--- a/master-standalone-strict/serviceentry-networking-v1alpha3.json
+++ b/master-standalone-strict/serviceentry-networking-v1alpha3.json
@@ -16,34 +16,62 @@
             "properties": {
               "address": {
                 "description": "Address associated with the network endpoint without the port.",
-                "type": "string"
+                "maxLength": 256,
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "UDS must be an absolute path or abstract socket",
+                    "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                  },
+                  {
+                    "message": "UDS may not be a dir",
+                    "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                  }
+                ]
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "One or more labels associated with the endpoint.",
+                "maxProperties": 256,
                 "type": "object"
               },
               "locality": {
                 "description": "The locality associated with the endpoint.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "network": {
                 "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "ports": {
                 "additionalProperties": {
                   "maximum": 4294967295,
                   "minimum": 0,
-                  "type": "integer"
+                  "type": "integer",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 },
                 "description": "Set of ports associated with the endpoint.",
-                "type": "object"
+                "maxProperties": 128,
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port name must be valid",
+                    "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                  }
+                ]
               },
               "serviceAccount": {
                 "description": "The service account associated with the workload if a sidecar is present in the workload.",
+                "maxLength": 253,
                 "type": "string"
               },
               "weight": {
@@ -53,8 +81,19 @@
                 "type": "integer"
               }
             },
-            "type": "object"
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "Address is required",
+                "rule": "has(self.address) || has(self.network)"
+              },
+              {
+                "message": "UDS may not include ports",
+                "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+              }
+            ]
           },
+          "maxItems": 4096,
           "type": "array"
         },
         "exportTo": {

--- a/master-standalone-strict/serviceentry-networking-v1beta1.json
+++ b/master-standalone-strict/serviceentry-networking-v1beta1.json
@@ -16,34 +16,62 @@
             "properties": {
               "address": {
                 "description": "Address associated with the network endpoint without the port.",
-                "type": "string"
+                "maxLength": 256,
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "UDS must be an absolute path or abstract socket",
+                    "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                  },
+                  {
+                    "message": "UDS may not be a dir",
+                    "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                  }
+                ]
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "One or more labels associated with the endpoint.",
+                "maxProperties": 256,
                 "type": "object"
               },
               "locality": {
                 "description": "The locality associated with the endpoint.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "network": {
                 "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "ports": {
                 "additionalProperties": {
                   "maximum": 4294967295,
                   "minimum": 0,
-                  "type": "integer"
+                  "type": "integer",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 },
                 "description": "Set of ports associated with the endpoint.",
-                "type": "object"
+                "maxProperties": 128,
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port name must be valid",
+                    "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                  }
+                ]
               },
               "serviceAccount": {
                 "description": "The service account associated with the workload if a sidecar is present in the workload.",
+                "maxLength": 253,
                 "type": "string"
               },
               "weight": {
@@ -53,8 +81,19 @@
                 "type": "integer"
               }
             },
-            "type": "object"
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "Address is required",
+                "rule": "has(self.address) || has(self.network)"
+              },
+              {
+                "message": "UDS may not include ports",
+                "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+              }
+            ]
           },
+          "maxItems": 4096,
           "type": "array"
         },
         "exportTo": {

--- a/master-standalone-strict/stage-kargo-v1alpha1.json
+++ b/master-standalone-strict/stage-kargo-v1alpha1.json
@@ -34,6 +34,27 @@
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                     "type": "string"
                   },
+                  "origin": {
+                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional, but Promotions will fail if there\nis ever ambiguity regarding which piece of Freight from which an artifact\nis to be sourced.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                        "enum": [
+                          "Warehouse"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
                   "sourceUpdates": {
                     "description": "SourceUpdates describes updates to be applied to various sources of the\nspecified Argo CD Application resource.",
                     "items": {
@@ -61,6 +82,27 @@
                                     "minLength": 1,
                                     "type": "string"
                                   },
+                                  "origin": {
+                                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDHelm's Origin field. If\nthat, too, is unspecified, Promotions will fail if there is ever ambiguity\nregarding from which piece of Freight an artifact is to be sourced.",
+                                    "properties": {
+                                      "kind": {
+                                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                        "enum": [
+                                          "Warehouse"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
                                   "value": {
                                     "description": "Value specifies the new value for the specified key in the Argo CD\nApplication's Helm parameters. Valid values are:\n\n\n- ImageAndTag: Replaces the value of the specified key with\n  <image name>:<tag>\n- Tag: Replaces the value of the specified key with just the new tag\n- ImageAndDigest: Replaces the value of the specified key with\n  <image name>@<digest>\n- Digest: Replaces the value of the specified key with just the new digest.\n\n\nThis is a required field.",
                                     "enum": [
@@ -81,6 +123,27 @@
                               },
                               "minItems": 1,
                               "type": "array"
+                            },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDSourceUpdate's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
                             }
                           },
                           "required": [
@@ -101,6 +164,27 @@
                                     "minLength": 1,
                                     "type": "string"
                                   },
+                                  "origin": {
+                                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDKustomize's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                                    "properties": {
+                                      "kind": {
+                                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                        "enum": [
+                                          "Warehouse"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
                                   "useDigest": {
                                     "description": "UseDigest specifies whether the image's digest should be used instead of\nits tag.",
                                     "type": "boolean"
@@ -113,10 +197,52 @@
                               },
                               "minItems": 1,
                               "type": "array"
+                            },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDSourceUpdate's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
                             }
                           },
                           "required": [
                             "images"
+                          ],
+                          "type": "object"
+                        },
+                        "origin": {
+                          "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDAppUpdate's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                          "properties": {
+                            "kind": {
+                              "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                              "enum": [
+                                "Warehouse"
+                              ],
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
                           ],
                           "type": "object"
                         },
@@ -169,6 +295,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing HelmPromotionMechanism's\nOrigin field. If that, too, is unspecified, Promotions will fail if there\nis ever ambiguity regarding from which piece of Freight an artifact is to\nbe sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "repository": {
                               "description": "Repository along with Name identifies a subchart of the umbrella chart at\nChartPath whose version should be updated. The values of both fields should\nexactly match the values of the fields of the same names in a dependency\nexpressed in the Chart.yaml of the umbrella chart at ChartPath. i.e. Do not\nmatch the values of these two fields to your Warehouse; match them to the\nChart.yaml. This is a required field.",
                               "minLength": 1,
@@ -201,6 +348,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing HelmPromotionMechanism's\nOrigin field. If that, too, is unspecified, Promotions will fail if there\nis ever ambiguity regarding from which piece of Freight an artifact is to\nbe sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "value": {
                               "description": "Value specifies the new value for the specified key in the specified Helm\nvalues file. Valid values are:\n\n\n- ImageAndTag: Replaces the value of the specified key with\n  <image name>:<tag>\n- Tag: Replaces the value of the specified key with just the new tag\n- ImageAndDigest: Replaces the value of the specified key with\n  <image name>@<digest>\n- Digest: Replaces the value of the specified key with just the new digest.\n\n\nThis is a required field.",
                               "enum": [
@@ -227,6 +395,27 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "origin": {
+                        "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing GitRepoUpdate's Origin field.\nIf that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                            "enum": [
+                              "Warehouse"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -248,6 +437,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing KustomizePromotionMechanism's\nOrigin field. If that, too, is unspecified, Promotions will fail if there\nis ever ambiguity regarding from which piece of Freight an artifact is to\nbe sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "path": {
                               "description": "Path specifies a path in which the `kustomize edit set image` command\nshould be executed. This is a required field.",
                               "minLength": 1,
@@ -267,10 +477,52 @@
                         },
                         "minItems": 1,
                         "type": "array"
+                      },
+                      "origin": {
+                        "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing GitRepoUpdate's Origin field.\nIf that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                            "enum": [
+                              "Warehouse"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object"
                       }
                     },
                     "required": [
                       "images"
+                    ],
+                    "type": "object"
+                  },
+                  "origin": {
+                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, the branch\nchecked out by this promotion mechanism will be the one specified by the\nReadBranch field. If that, too, is unspecified, the default branch of the\nrepository will be checked out. Always provide a value for this field if\nwishing to check out a specific commit indicated by a piece of Freight.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                        "enum": [
+                          "Warehouse"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
                     ],
                     "type": "object"
                   },
@@ -306,6 +558,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing\nKargoRenderPromotionMechanism's Origin field. If that, too, is unspecified,\nPromotions will fail if there is ever ambiguity regarding from which piece\nof Freight an artifact is to be sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "useDigest": {
                               "description": "UseDigest specifies whether the image's digest should be used instead of\nits tag.",
                               "type": "boolean"
@@ -317,6 +590,27 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "origin": {
+                        "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing GitRepoUpdate's Origin field.\nIf that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                            "enum": [
+                              "Warehouse"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -341,22 +635,97 @@
                 "type": "object"
               },
               "type": "array"
+            },
+            "origin": {
+              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. Its value is overridable by\nchild promotion mechanisms.",
+              "properties": {
+                "kind": {
+                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                  "enum": [
+                    "Warehouse"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "requestedFreight": {
+          "description": "RequestedFreight expresses the Stage's need for certain pieces of Freight,\neach having originated from a particular Warehouse. This list must be\nnon-empty. In the common case, a Stage will request Freight having\noriginated from just one specific Warehouse. In advanced cases, requesting\nFreight from multiple Warehouses provides a method of advancing new\nartifacts of different types through parallel pipelines at different\nspeeds. This can be useful, for instance, if a Stage is home to multiple\nmicroservices that are independently versioned.",
+          "items": {
+            "description": "FreightRequest expresses a Stage's need for Freight having originated from a\nparticular Warehouse.",
+            "properties": {
+              "origin": {
+                "description": "Origin specifies from where the requested Freight must have originated.\nThis is a required field.",
+                "properties": {
+                  "kind": {
+                    "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                    "enum": [
+                      "Warehouse"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "sources": {
+                "description": "Sources describes where the requested Freight may be obtained from. This is\na required field.",
+                "properties": {
+                  "direct": {
+                    "description": "Direct indicates the requested Freight may be obtained directly from the\nWarehouse from which it originated. If this field's value is false, then\nthe value of the Stages field must be non-empty. i.e. Between the two\nfields, at least one source must be specified.",
+                    "type": "boolean"
+                  },
+                  "stages": {
+                    "description": "Stages identifies other \"upstream\" Stages as potential sources of the\nrequested Freight. If this field's value is empty, then the value of the\nDirect field must be true. i.e. Between the two fields, at least on source\nmust be specified.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "origin",
+              "sources"
+            ],
+            "type": "object"
+          },
+          "minItems": 1,
+          "type": "array"
         },
         "shard": {
           "description": "Shard is the name of the shard that this Stage belongs to. This is an\noptional field. If not specified, the Stage will belong to the default\nshard. A defaulting webhook will sync the value of the\nkargo.akuity.io/shard label with the value of this field. When this field\nis empty, the webhook will ensure that label is absent.",
           "type": "string"
         },
         "subscriptions": {
-          "description": "Subscriptions describes the Stage's sources of Freight. This is a required\nfield.",
+          "description": "Subscriptions describes the Stage's sources of Freight. This is a required\nfield.\n\n\nDeprecated: Use RequestedFreight instead.",
           "properties": {
             "upstreamStages": {
               "description": "UpstreamStages identifies other Stages as potential sources of Freight\nfor this Stage. This field is mutually exclusive with the Repos field.",
               "items": {
-                "description": "StageSubscription defines a subscription to Freight from another Stage.",
+                "description": "StageSubscription defines a subscription to Freight from another Stage.\n\n\nDeprecated: Use FreightRequest instead.",
                 "properties": {
                   "name": {
                     "description": "Name specifies the name of a Stage.",
@@ -448,6 +817,7 @@
         }
       },
       "required": [
+        "requestedFreight",
         "subscriptions"
       ],
       "type": "object",
@@ -457,7 +827,7 @@
       "description": "Status describes the Stage's current and recent Freight, health, and more.",
       "properties": {
         "currentFreight": {
-          "description": "CurrentFreight is a simplified representation of the Stage's current\nFreight describing what is currently deployed to the Stage.",
+          "description": "CurrentFreight is a simplified representation of the Stage's current\nFreight describing what is currently deployed to the Stage.\n\n\nDeprecated: Use the top item in the FreightHistory stack instead.",
           "properties": {
             "charts": {
               "description": "Charts describes specific versions of specific Helm charts.",
@@ -499,7 +869,7 @@
                     "type": "string"
                   },
                   "healthCheckCommit": {
-                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                     "type": "string"
                   },
                   "id": {
@@ -553,10 +923,31 @@
               "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
               "type": "string"
             },
+            "origin": {
+              "description": "Origin describes a kind of Freight in terms of its origin.",
+              "properties": {
+                "kind": {
+                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                  "enum": [
+                    "Warehouse"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object"
+            },
             "verificationHistory": {
-              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "items": {
-                "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                 "properties": {
                   "actor": {
                     "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -613,7 +1004,7 @@
               "type": "array"
             },
             "verificationInfo": {
-              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "properties": {
                 "actor": {
                   "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -668,7 +1059,7 @@
               "type": "object"
             },
             "warehouse": {
-              "description": "Warehouse is the name of the Warehouse that created this Freight.",
+              "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
               "type": "string"
             }
           },
@@ -725,7 +1116,7 @@
                         "type": "string"
                       },
                       "healthCheckCommit": {
-                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                         "type": "string"
                       },
                       "id": {
@@ -779,10 +1170,31 @@
                   "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                   "type": "string"
                 },
+                "origin": {
+                  "description": "Origin describes a kind of Freight in terms of its origin.",
+                  "properties": {
+                    "kind": {
+                      "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                      "enum": [
+                        "Warehouse"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object"
+                },
                 "verificationHistory": {
-                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "items": {
-                    "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                    "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                     "properties": {
                       "actor": {
                         "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -839,7 +1251,7 @@
                   "type": "array"
                 },
                 "verificationInfo": {
-                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "properties": {
                     "actor": {
                       "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -894,7 +1306,7 @@
                   "type": "object"
                 },
                 "warehouse": {
-                  "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                  "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                   "type": "string"
                 }
               },
@@ -955,7 +1367,7 @@
                             "type": "string"
                           },
                           "healthCheckCommit": {
-                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                             "type": "string"
                           },
                           "id": {
@@ -1009,10 +1421,31 @@
                       "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                       "type": "string"
                     },
+                    "origin": {
+                      "description": "Origin describes a kind of Freight in terms of its origin.",
+                      "properties": {
+                        "kind": {
+                          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                          "enum": [
+                            "Warehouse"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
                     "verificationHistory": {
-                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "items": {
-                        "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                         "properties": {
                           "actor": {
                             "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1069,7 +1502,7 @@
                       "type": "array"
                     },
                     "verificationInfo": {
-                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "properties": {
                         "actor": {
                           "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1124,10 +1557,325 @@
                       "type": "object"
                     },
                     "warehouse": {
-                      "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                      "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                       "type": "string"
                     }
                   },
+                  "type": "object"
+                },
+                "freightCollection": {
+                  "description": "FreightCollection contains the details of the piece of Freight referenced\nby this Promotion as well as any additional Freight that is carried over\nfrom the target Stage's current state.",
+                  "properties": {
+                    "id": {
+                      "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+                      "type": "string"
+                    },
+                    "items": {
+                      "additionalProperties": {
+                        "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                        "properties": {
+                          "charts": {
+                            "description": "Charts describes specific versions of specific Helm charts.",
+                            "items": {
+                              "description": "Chart describes a specific version of a Helm chart.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies the name of the chart.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "description": "Version specifies a particular version of the chart.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "commits": {
+                            "description": "Commits describes specific Git repository commits.",
+                            "items": {
+                              "description": "GitCommit describes a specific commit from a specific Git repository.",
+                              "properties": {
+                                "author": {
+                                  "description": "Author is the author of the commit.",
+                                  "type": "string"
+                                },
+                                "branch": {
+                                  "description": "Branch denotes the branch of the repository where this commit was found.",
+                                  "type": "string"
+                                },
+                                "committer": {
+                                  "description": "Committer is the person who committed the commit.",
+                                  "type": "string"
+                                },
+                                "healthCheckCommit": {
+                                  "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL is the URL of a Git repository.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "images": {
+                            "description": "Images describes specific versions of specific container images.",
+                            "items": {
+                              "description": "Image describes a specific version of a container image.",
+                              "properties": {
+                                "digest": {
+                                  "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                                  "type": "string"
+                                },
+                                "gitRepoURL": {
+                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL describes the repository in which the image can be found.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                            "type": "string"
+                          },
+                          "origin": {
+                            "description": "Origin describes a kind of Freight in terms of its origin.",
+                            "properties": {
+                              "kind": {
+                                "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                "enum": [
+                                  "Warehouse"
+                                ],
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "verificationHistory": {
+                            "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "items": {
+                              "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                              "properties": {
+                                "actor": {
+                                  "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                  "type": "string"
+                                },
+                                "analysisRun": {
+                                  "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "description": "Namespace is the namespace of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "phase": {
+                                      "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "namespace",
+                                    "phase"
+                                  ],
+                                  "type": "object"
+                                },
+                                "finishTime": {
+                                  "description": "FinishTime is the time at which the Verification process finished.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the identifier of the Verification process.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                  "type": "string"
+                                },
+                                "phase": {
+                                  "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                  "type": "string"
+                                },
+                                "startTime": {
+                                  "description": "StartTime is the time at which the Verification process was started.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "verificationInfo": {
+                            "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "properties": {
+                              "actor": {
+                                "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                "type": "string"
+                              },
+                              "analysisRun": {
+                                "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the name of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "phase": {
+                                    "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "namespace",
+                                  "phase"
+                                ],
+                                "type": "object"
+                              },
+                              "finishTime": {
+                                "description": "FinishTime is the time at which the Verification process finished.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "id": {
+                                "description": "ID is the identifier of the Verification process.",
+                                "type": "string"
+                              },
+                              "message": {
+                                "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                "type": "string"
+                              },
+                              "startTime": {
+                                "description": "StartTime is the time at which the Verification process was started.",
+                                "format": "date-time",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "warehouse": {
+                            "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+                      "type": "object"
+                    },
+                    "verificationHistory": {
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "items": {
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                        "properties": {
+                          "actor": {
+                            "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                            "type": "string"
+                          },
+                          "analysisRun": {
+                            "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "namespace",
+                              "phase"
+                            ],
+                            "type": "object"
+                          },
+                          "finishTime": {
+                            "description": "FinishTime is the time at which the Verification process finished.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the identifier of the Verification process.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                            "type": "string"
+                          },
+                          "startTime": {
+                            "description": "StartTime is the time at which the Verification process was started.",
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
                   "type": "object"
                 },
                 "lastHandledRefresh": {
@@ -1154,10 +1902,332 @@
             }
           },
           "required": [
-            "freight",
             "name"
           ],
           "type": "object"
+        },
+        "freightHistory": {
+          "description": "FreightHistory is a list of recent Freight selections that were deployed\nto the Stage. By default, the last ten Freight selections are stored.\nThe first item in the list is the most recent Freight selection and\ncurrently deployed to the Stage, subsequent items are older selections.",
+          "items": {
+            "description": "FreightCollection is a collection of FreightReferences, each of which\nrepresents a piece of Freight that has been selected for deployment to a\nStage.",
+            "properties": {
+              "id": {
+                "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+                "type": "string"
+              },
+              "items": {
+                "additionalProperties": {
+                  "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                  "properties": {
+                    "charts": {
+                      "description": "Charts describes specific versions of specific Helm charts.",
+                      "items": {
+                        "description": "Chart describes a specific version of a Helm chart.",
+                        "properties": {
+                          "name": {
+                            "description": "Name specifies the name of the chart.",
+                            "type": "string"
+                          },
+                          "repoURL": {
+                            "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "Version specifies a particular version of the chart.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "commits": {
+                      "description": "Commits describes specific Git repository commits.",
+                      "items": {
+                        "description": "GitCommit describes a specific commit from a specific Git repository.",
+                        "properties": {
+                          "author": {
+                            "description": "Author is the author of the commit.",
+                            "type": "string"
+                          },
+                          "branch": {
+                            "description": "Branch denotes the branch of the repository where this commit was found.",
+                            "type": "string"
+                          },
+                          "committer": {
+                            "description": "Committer is the person who committed the commit.",
+                            "type": "string"
+                          },
+                          "healthCheckCommit": {
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                            "type": "string"
+                          },
+                          "repoURL": {
+                            "description": "RepoURL is the URL of a Git repository.",
+                            "type": "string"
+                          },
+                          "tag": {
+                            "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "images": {
+                      "description": "Images describes specific versions of specific container images.",
+                      "items": {
+                        "description": "Image describes a specific version of a container image.",
+                        "properties": {
+                          "digest": {
+                            "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                            "type": "string"
+                          },
+                          "gitRepoURL": {
+                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                            "type": "string"
+                          },
+                          "repoURL": {
+                            "description": "RepoURL describes the repository in which the image can be found.",
+                            "type": "string"
+                          },
+                          "tag": {
+                            "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                      "type": "string"
+                    },
+                    "origin": {
+                      "description": "Origin describes a kind of Freight in terms of its origin.",
+                      "properties": {
+                        "kind": {
+                          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                          "enum": [
+                            "Warehouse"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "verificationHistory": {
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                      "items": {
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                        "properties": {
+                          "actor": {
+                            "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                            "type": "string"
+                          },
+                          "analysisRun": {
+                            "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "namespace",
+                              "phase"
+                            ],
+                            "type": "object"
+                          },
+                          "finishTime": {
+                            "description": "FinishTime is the time at which the Verification process finished.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the identifier of the Verification process.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                            "type": "string"
+                          },
+                          "startTime": {
+                            "description": "StartTime is the time at which the Verification process was started.",
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "verificationInfo": {
+                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                      "properties": {
+                        "actor": {
+                          "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                          "type": "string"
+                        },
+                        "analysisRun": {
+                          "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "phase": {
+                              "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "namespace",
+                            "phase"
+                          ],
+                          "type": "object"
+                        },
+                        "finishTime": {
+                          "description": "FinishTime is the time at which the Verification process finished.",
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the identifier of the Verification process.",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                          "type": "string"
+                        },
+                        "phase": {
+                          "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                          "type": "string"
+                        },
+                        "startTime": {
+                          "description": "StartTime is the time at which the Verification process was started.",
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "warehouse": {
+                      "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+                "type": "object"
+              },
+              "verificationHistory": {
+                "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                "items": {
+                  "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                  "properties": {
+                    "actor": {
+                      "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                      "type": "string"
+                    },
+                    "analysisRun": {
+                      "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of the AnalysisRun.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the namespace of the AnalysisRun.",
+                          "type": "string"
+                        },
+                        "phase": {
+                          "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "namespace",
+                        "phase"
+                      ],
+                      "type": "object"
+                    },
+                    "finishTime": {
+                      "description": "FinishTime is the time at which the Verification process finished.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "ID is the identifier of the Verification process.",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                      "type": "string"
+                    },
+                    "phase": {
+                      "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                      "type": "string"
+                    },
+                    "startTime": {
+                      "description": "StartTime is the time at which the Verification process was started.",
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "freightSummary": {
+          "description": "FreightSummary is human-readable text maintained by the controller that\nsummarizes what Freight is currently deployed to the Stage. For Stages that\nrequest a single piece of Freight AND the request has been fulfilled, this\nfield will simply contain the name of the Freight. For Stages that request\na single piece of Freight AND the request has NOT been fulfilled, or for\nStages that request multiple pieces of Freight, this field will contain a\nsummary of fulfilled/requested Freight. The existence of this field is a\nworkaround for kubectl limitations so that this complex but valuable\ninformation can be displayed in a column in response to `kubectl get\nstages`.",
+          "type": "string"
         },
         "health": {
           "description": "Health is the Stage's last observed health.",
@@ -1235,7 +2305,7 @@
           "type": "object"
         },
         "history": {
-          "description": "History is a stack of recent Freight. By default, the last ten Freight are\nstored.",
+          "description": "History is a stack of recent Freight. By default, the last ten Freight are\nstored.\n\n\nDeprecated: Use the FreightHistory stack instead.",
           "items": {
             "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
             "properties": {
@@ -1279,7 +2349,7 @@
                       "type": "string"
                     },
                     "healthCheckCommit": {
-                      "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                      "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                       "type": "string"
                     },
                     "id": {
@@ -1333,10 +2403,31 @@
                 "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                 "type": "string"
               },
+              "origin": {
+                "description": "Origin describes a kind of Freight in terms of its origin.",
+                "properties": {
+                  "kind": {
+                    "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                    "enum": [
+                      "Warehouse"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name"
+                ],
+                "type": "object"
+              },
               "verificationHistory": {
-                "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                 "items": {
-                  "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                  "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                   "properties": {
                     "actor": {
                       "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1393,7 +2484,7 @@
                 "type": "array"
               },
               "verificationInfo": {
-                "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                 "properties": {
                   "actor": {
                     "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1448,7 +2539,7 @@
                 "type": "object"
               },
               "warehouse": {
-                "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                 "type": "string"
               }
             },
@@ -1511,7 +2602,7 @@
                         "type": "string"
                       },
                       "healthCheckCommit": {
-                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                         "type": "string"
                       },
                       "id": {
@@ -1565,10 +2656,31 @@
                   "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                   "type": "string"
                 },
+                "origin": {
+                  "description": "Origin describes a kind of Freight in terms of its origin.",
+                  "properties": {
+                    "kind": {
+                      "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                      "enum": [
+                        "Warehouse"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object"
+                },
                 "verificationHistory": {
-                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "items": {
-                    "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                    "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                     "properties": {
                       "actor": {
                         "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1625,7 +2737,7 @@
                   "type": "array"
                 },
                 "verificationInfo": {
-                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "properties": {
                     "actor": {
                       "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1680,7 +2792,7 @@
                   "type": "object"
                 },
                 "warehouse": {
-                  "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                  "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                   "type": "string"
                 }
               },
@@ -1741,7 +2853,7 @@
                             "type": "string"
                           },
                           "healthCheckCommit": {
-                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                             "type": "string"
                           },
                           "id": {
@@ -1795,10 +2907,31 @@
                       "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                       "type": "string"
                     },
+                    "origin": {
+                      "description": "Origin describes a kind of Freight in terms of its origin.",
+                      "properties": {
+                        "kind": {
+                          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                          "enum": [
+                            "Warehouse"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
                     "verificationHistory": {
-                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "items": {
-                        "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                         "properties": {
                           "actor": {
                             "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1855,7 +2988,7 @@
                       "type": "array"
                     },
                     "verificationInfo": {
-                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "properties": {
                         "actor": {
                           "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1910,10 +3043,325 @@
                       "type": "object"
                     },
                     "warehouse": {
-                      "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                      "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                       "type": "string"
                     }
                   },
+                  "type": "object"
+                },
+                "freightCollection": {
+                  "description": "FreightCollection contains the details of the piece of Freight referenced\nby this Promotion as well as any additional Freight that is carried over\nfrom the target Stage's current state.",
+                  "properties": {
+                    "id": {
+                      "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+                      "type": "string"
+                    },
+                    "items": {
+                      "additionalProperties": {
+                        "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                        "properties": {
+                          "charts": {
+                            "description": "Charts describes specific versions of specific Helm charts.",
+                            "items": {
+                              "description": "Chart describes a specific version of a Helm chart.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies the name of the chart.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "description": "Version specifies a particular version of the chart.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "commits": {
+                            "description": "Commits describes specific Git repository commits.",
+                            "items": {
+                              "description": "GitCommit describes a specific commit from a specific Git repository.",
+                              "properties": {
+                                "author": {
+                                  "description": "Author is the author of the commit.",
+                                  "type": "string"
+                                },
+                                "branch": {
+                                  "description": "Branch denotes the branch of the repository where this commit was found.",
+                                  "type": "string"
+                                },
+                                "committer": {
+                                  "description": "Committer is the person who committed the commit.",
+                                  "type": "string"
+                                },
+                                "healthCheckCommit": {
+                                  "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL is the URL of a Git repository.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "images": {
+                            "description": "Images describes specific versions of specific container images.",
+                            "items": {
+                              "description": "Image describes a specific version of a container image.",
+                              "properties": {
+                                "digest": {
+                                  "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                                  "type": "string"
+                                },
+                                "gitRepoURL": {
+                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL describes the repository in which the image can be found.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                            "type": "string"
+                          },
+                          "origin": {
+                            "description": "Origin describes a kind of Freight in terms of its origin.",
+                            "properties": {
+                              "kind": {
+                                "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                "enum": [
+                                  "Warehouse"
+                                ],
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "verificationHistory": {
+                            "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "items": {
+                              "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                              "properties": {
+                                "actor": {
+                                  "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                  "type": "string"
+                                },
+                                "analysisRun": {
+                                  "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "description": "Namespace is the namespace of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "phase": {
+                                      "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "namespace",
+                                    "phase"
+                                  ],
+                                  "type": "object"
+                                },
+                                "finishTime": {
+                                  "description": "FinishTime is the time at which the Verification process finished.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the identifier of the Verification process.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                  "type": "string"
+                                },
+                                "phase": {
+                                  "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                  "type": "string"
+                                },
+                                "startTime": {
+                                  "description": "StartTime is the time at which the Verification process was started.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "verificationInfo": {
+                            "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "properties": {
+                              "actor": {
+                                "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                "type": "string"
+                              },
+                              "analysisRun": {
+                                "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the name of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "phase": {
+                                    "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "namespace",
+                                  "phase"
+                                ],
+                                "type": "object"
+                              },
+                              "finishTime": {
+                                "description": "FinishTime is the time at which the Verification process finished.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "id": {
+                                "description": "ID is the identifier of the Verification process.",
+                                "type": "string"
+                              },
+                              "message": {
+                                "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                "type": "string"
+                              },
+                              "startTime": {
+                                "description": "StartTime is the time at which the Verification process was started.",
+                                "format": "date-time",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "warehouse": {
+                            "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+                      "type": "object"
+                    },
+                    "verificationHistory": {
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "items": {
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                        "properties": {
+                          "actor": {
+                            "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                            "type": "string"
+                          },
+                          "analysisRun": {
+                            "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "namespace",
+                              "phase"
+                            ],
+                            "type": "object"
+                          },
+                          "finishTime": {
+                            "description": "FinishTime is the time at which the Verification process finished.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the identifier of the Verification process.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                            "type": "string"
+                          },
+                          "startTime": {
+                            "description": "StartTime is the time at which the Verification process was started.",
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
                   "type": "object"
                 },
                 "lastHandledRefresh": {
@@ -1940,7 +3388,6 @@
             }
           },
           "required": [
-            "freight",
             "name"
           ],
           "type": "object"

--- a/master-standalone-strict/targetgroupbinding-elbv2-v1alpha1.json
+++ b/master-standalone-strict/targetgroupbinding-elbv2-v1alpha1.json
@@ -2,11 +2,11 @@
   "description": "TargetGroupBinding is the Schema for the TargetGroupBinding API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -23,15 +23,15 @@
               "items": {
                 "properties": {
                   "from": {
-                    "description": "List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.",
+                    "description": "List of peers which should be able to access the targets in TargetGroup.\nAt least one NetworkingPeer should be specified.",
                     "items": {
                       "description": "NetworkingPeer defines the source/destination peer for networking rules.",
                       "properties": {
                         "ipBlock": {
-                          "description": "IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.",
+                          "description": "IPBlock defines an IPBlock peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "cidr": {
-                              "description": "CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.",
+                              "description": "CIDR is the network CIDR.\nBoth IPV4 or IPV6 CIDR are accepted.",
                               "type": "string"
                             }
                           },
@@ -41,7 +41,7 @@
                           "type": "object"
                         },
                         "securityGroup": {
-                          "description": "SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.",
+                          "description": "SecurityGroup defines a SecurityGroup peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "groupID": {
                               "description": "GroupID is the EC2 SecurityGroupID.",
@@ -59,7 +59,7 @@
                     "type": "array"
                   },
                   "ports": {
-                    "description": "List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.",
+                    "description": "List of ports which should be made accessible on the targets in TargetGroup.\nIf ports is empty or unspecified, it defaults to all ports with TCP.",
                     "items": {
                       "properties": {
                         "port": {
@@ -71,11 +71,11 @@
                               "type": "string"
                             }
                           ],
-                          "description": "The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.",
+                          "description": "The port which traffic must match.\nWhen NodePort endpoints(instance TargetType) is used, this must be a numerical port.\nWhen Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.\nif port is unspecified, it defaults to all ports.",
                           "x-kubernetes-int-or-string": true
                         },
                         "protocol": {
-                          "description": "The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.",
+                          "description": "The protocol which traffic must match.\nIf protocol is unspecified, it defaults to TCP.",
                           "enum": [
                             "TCP",
                             "UDP"

--- a/master-standalone-strict/targetgroupbinding-elbv2-v1beta1.json
+++ b/master-standalone-strict/targetgroupbinding-elbv2-v1beta1.json
@@ -2,11 +2,11 @@
   "description": "TargetGroupBinding is the Schema for the TargetGroupBinding API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -32,15 +32,15 @@
                 "description": "NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.",
                 "properties": {
                   "from": {
-                    "description": "List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.",
+                    "description": "List of peers which should be able to access the targets in TargetGroup.\nAt least one NetworkingPeer should be specified.",
                     "items": {
                       "description": "NetworkingPeer defines the source/destination peer for networking rules.",
                       "properties": {
                         "ipBlock": {
-                          "description": "IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.",
+                          "description": "IPBlock defines an IPBlock peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "cidr": {
-                              "description": "CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.",
+                              "description": "CIDR is the network CIDR.\nBoth IPV4 or IPV6 CIDR are accepted.",
                               "type": "string"
                             }
                           },
@@ -50,7 +50,7 @@
                           "type": "object"
                         },
                         "securityGroup": {
-                          "description": "SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.",
+                          "description": "SecurityGroup defines a SecurityGroup peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "groupID": {
                               "description": "GroupID is the EC2 SecurityGroupID.",
@@ -68,7 +68,7 @@
                     "type": "array"
                   },
                   "ports": {
-                    "description": "List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.",
+                    "description": "List of ports which should be made accessible on the targets in TargetGroup.\nIf ports is empty or unspecified, it defaults to all ports with TCP.",
                     "items": {
                       "description": "NetworkingPort defines the port and protocol for networking rules.",
                       "properties": {
@@ -81,11 +81,11 @@
                               "type": "string"
                             }
                           ],
-                          "description": "The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.",
+                          "description": "The port which traffic must match.\nWhen NodePort endpoints(instance TargetType) is used, this must be a numerical port.\nWhen Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.\nif port is unspecified, it defaults to all ports.",
                           "x-kubernetes-int-or-string": true
                         },
                         "protocol": {
-                          "description": "The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.",
+                          "description": "The protocol which traffic must match.\nIf protocol is unspecified, it defaults to TCP.",
                           "enum": [
                             "TCP",
                             "UDP"
@@ -116,22 +116,23 @@
             "matchExpressions": {
               "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
                     "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "required": [
@@ -140,17 +141,19 @@
                 ],
                 "type": "object"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "matchLabels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
           "type": "object",
+          "x-kubernetes-map-type": "atomic",
           "additionalProperties": false
         },
         "serviceRef": {
@@ -191,6 +194,10 @@
             "instance",
             "ip"
           ],
+          "type": "string"
+        },
+        "vpcID": {
+          "description": "VpcID is the VPC of the TargetGroup. If unspecified, it will be automatically inferred.",
           "type": "string"
         }
       },

--- a/master-standalone-strict/vaultdynamicsecret-generators-v1alpha1.json
+++ b/master-standalone-strict/vaultdynamicsecret-generators-v1alpha1.json
@@ -562,6 +562,13 @@
               "description": "ForwardInconsistent tells Vault to forward read-after-write requests to the Vault\nleader instead of simply retrying within a loop. This can increase performance if\nthe option is enabled serverside.\nhttps://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header",
               "type": "boolean"
             },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Headers to be added in Vault request",
+              "type": "object"
+            },
             "namespace": {
               "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows\nVault environments to support Secure Multi-tenancy. e.g: \"ns1\".\nMore about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
               "type": "string"

--- a/master-standalone-strict/workloadentry-networking-v1.json
+++ b/master-standalone-strict/workloadentry-networking-v1.json
@@ -5,34 +5,62 @@
       "properties": {
         "address": {
           "description": "Address associated with the network endpoint without the port.",
-          "type": "string"
+          "maxLength": 256,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS must be an absolute path or abstract socket",
+              "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+            },
+            {
+              "message": "UDS may not be a dir",
+              "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+            }
+          ]
         },
         "labels": {
           "additionalProperties": {
             "type": "string"
           },
           "description": "One or more labels associated with the endpoint.",
+          "maxProperties": 256,
           "type": "object"
         },
         "locality": {
           "description": "The locality associated with the endpoint.",
+          "maxLength": 2048,
           "type": "string"
         },
         "network": {
           "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+          "maxLength": 2048,
           "type": "string"
         },
         "ports": {
           "additionalProperties": {
             "maximum": 4294967295,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-kubernetes-validations": [
+              {
+                "message": "port must be between 1-65535",
+                "rule": "0 < self && self <= 65535"
+              }
+            ]
           },
           "description": "Set of ports associated with the endpoint.",
-          "type": "object"
+          "maxProperties": 128,
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port name must be valid",
+              "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+            }
+          ]
         },
         "serviceAccount": {
           "description": "The service account associated with the workload if a sidecar is present in the workload.",
+          "maxLength": 253,
           "type": "string"
         },
         "weight": {
@@ -43,6 +71,16 @@
         }
       },
       "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "Address is required",
+          "rule": "has(self.address) || has(self.network)"
+        },
+        {
+          "message": "UDS may not include ports",
+          "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+        }
+      ],
       "additionalProperties": false
     },
     "status": {
@@ -50,5 +88,10 @@
       "x-kubernetes-preserve-unknown-fields": true
     }
   },
+  "required": [
+    "spec",
+    "spec",
+    "spec"
+  ],
   "type": "object"
 }

--- a/master-standalone-strict/workloadentry-networking-v1alpha3.json
+++ b/master-standalone-strict/workloadentry-networking-v1alpha3.json
@@ -5,34 +5,62 @@
       "properties": {
         "address": {
           "description": "Address associated with the network endpoint without the port.",
-          "type": "string"
+          "maxLength": 256,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS must be an absolute path or abstract socket",
+              "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+            },
+            {
+              "message": "UDS may not be a dir",
+              "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+            }
+          ]
         },
         "labels": {
           "additionalProperties": {
             "type": "string"
           },
           "description": "One or more labels associated with the endpoint.",
+          "maxProperties": 256,
           "type": "object"
         },
         "locality": {
           "description": "The locality associated with the endpoint.",
+          "maxLength": 2048,
           "type": "string"
         },
         "network": {
           "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+          "maxLength": 2048,
           "type": "string"
         },
         "ports": {
           "additionalProperties": {
             "maximum": 4294967295,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-kubernetes-validations": [
+              {
+                "message": "port must be between 1-65535",
+                "rule": "0 < self && self <= 65535"
+              }
+            ]
           },
           "description": "Set of ports associated with the endpoint.",
-          "type": "object"
+          "maxProperties": 128,
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port name must be valid",
+              "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+            }
+          ]
         },
         "serviceAccount": {
           "description": "The service account associated with the workload if a sidecar is present in the workload.",
+          "maxLength": 253,
           "type": "string"
         },
         "weight": {
@@ -43,6 +71,16 @@
         }
       },
       "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "Address is required",
+          "rule": "has(self.address) || has(self.network)"
+        },
+        {
+          "message": "UDS may not include ports",
+          "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+        }
+      ],
       "additionalProperties": false
     },
     "status": {
@@ -50,5 +88,10 @@
       "x-kubernetes-preserve-unknown-fields": true
     }
   },
+  "required": [
+    "spec",
+    "spec",
+    "spec"
+  ],
   "type": "object"
 }

--- a/master-standalone-strict/workloadentry-networking-v1beta1.json
+++ b/master-standalone-strict/workloadentry-networking-v1beta1.json
@@ -5,34 +5,62 @@
       "properties": {
         "address": {
           "description": "Address associated with the network endpoint without the port.",
-          "type": "string"
+          "maxLength": 256,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS must be an absolute path or abstract socket",
+              "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+            },
+            {
+              "message": "UDS may not be a dir",
+              "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+            }
+          ]
         },
         "labels": {
           "additionalProperties": {
             "type": "string"
           },
           "description": "One or more labels associated with the endpoint.",
+          "maxProperties": 256,
           "type": "object"
         },
         "locality": {
           "description": "The locality associated with the endpoint.",
+          "maxLength": 2048,
           "type": "string"
         },
         "network": {
           "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+          "maxLength": 2048,
           "type": "string"
         },
         "ports": {
           "additionalProperties": {
             "maximum": 4294967295,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-kubernetes-validations": [
+              {
+                "message": "port must be between 1-65535",
+                "rule": "0 < self && self <= 65535"
+              }
+            ]
           },
           "description": "Set of ports associated with the endpoint.",
-          "type": "object"
+          "maxProperties": 128,
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port name must be valid",
+              "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+            }
+          ]
         },
         "serviceAccount": {
           "description": "The service account associated with the workload if a sidecar is present in the workload.",
+          "maxLength": 253,
           "type": "string"
         },
         "weight": {
@@ -43,6 +71,16 @@
         }
       },
       "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "Address is required",
+          "rule": "has(self.address) || has(self.network)"
+        },
+        {
+          "message": "UDS may not include ports",
+          "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+        }
+      ],
       "additionalProperties": false
     },
     "status": {
@@ -50,5 +88,10 @@
       "x-kubernetes-preserve-unknown-fields": true
     }
   },
+  "required": [
+    "spec",
+    "spec",
+    "spec"
+  ],
   "type": "object"
 }

--- a/master-standalone-strict/workloadgroup-networking-v1.json
+++ b/master-standalone-strict/workloadgroup-networking-v1.json
@@ -171,34 +171,62 @@
           "properties": {
             "address": {
               "description": "Address associated with the network endpoint without the port.",
-              "type": "string"
+              "maxLength": 256,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "UDS must be an absolute path or abstract socket",
+                  "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                },
+                {
+                  "message": "UDS may not be a dir",
+                  "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                }
+              ]
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
               "description": "One or more labels associated with the endpoint.",
+              "maxProperties": 256,
               "type": "object"
             },
             "locality": {
               "description": "The locality associated with the endpoint.",
+              "maxLength": 2048,
               "type": "string"
             },
             "network": {
               "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+              "maxLength": 2048,
               "type": "string"
             },
             "ports": {
               "additionalProperties": {
                 "maximum": 4294967295,
                 "minimum": 0,
-                "type": "integer"
+                "type": "integer",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               },
               "description": "Set of ports associated with the endpoint.",
-              "type": "object"
+              "maxProperties": 128,
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "port name must be valid",
+                  "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                }
+              ]
             },
             "serviceAccount": {
               "description": "The service account associated with the workload if a sidecar is present in the workload.",
+              "maxLength": 253,
               "type": "string"
             },
             "weight": {
@@ -209,6 +237,16 @@
             }
           },
           "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Address is required",
+              "rule": "has(self.address) || has(self.network)"
+            },
+            {
+              "message": "UDS may not include ports",
+              "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+            }
+          ],
           "additionalProperties": false
         }
       },

--- a/master-standalone-strict/workloadgroup-networking-v1alpha3.json
+++ b/master-standalone-strict/workloadgroup-networking-v1alpha3.json
@@ -171,34 +171,62 @@
           "properties": {
             "address": {
               "description": "Address associated with the network endpoint without the port.",
-              "type": "string"
+              "maxLength": 256,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "UDS must be an absolute path or abstract socket",
+                  "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                },
+                {
+                  "message": "UDS may not be a dir",
+                  "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                }
+              ]
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
               "description": "One or more labels associated with the endpoint.",
+              "maxProperties": 256,
               "type": "object"
             },
             "locality": {
               "description": "The locality associated with the endpoint.",
+              "maxLength": 2048,
               "type": "string"
             },
             "network": {
               "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+              "maxLength": 2048,
               "type": "string"
             },
             "ports": {
               "additionalProperties": {
                 "maximum": 4294967295,
                 "minimum": 0,
-                "type": "integer"
+                "type": "integer",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               },
               "description": "Set of ports associated with the endpoint.",
-              "type": "object"
+              "maxProperties": 128,
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "port name must be valid",
+                  "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                }
+              ]
             },
             "serviceAccount": {
               "description": "The service account associated with the workload if a sidecar is present in the workload.",
+              "maxLength": 253,
               "type": "string"
             },
             "weight": {
@@ -209,6 +237,16 @@
             }
           },
           "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Address is required",
+              "rule": "has(self.address) || has(self.network)"
+            },
+            {
+              "message": "UDS may not include ports",
+              "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+            }
+          ],
           "additionalProperties": false
         }
       },

--- a/master-standalone-strict/workloadgroup-networking-v1beta1.json
+++ b/master-standalone-strict/workloadgroup-networking-v1beta1.json
@@ -171,34 +171,62 @@
           "properties": {
             "address": {
               "description": "Address associated with the network endpoint without the port.",
-              "type": "string"
+              "maxLength": 256,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "UDS must be an absolute path or abstract socket",
+                  "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                },
+                {
+                  "message": "UDS may not be a dir",
+                  "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                }
+              ]
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
               "description": "One or more labels associated with the endpoint.",
+              "maxProperties": 256,
               "type": "object"
             },
             "locality": {
               "description": "The locality associated with the endpoint.",
+              "maxLength": 2048,
               "type": "string"
             },
             "network": {
               "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+              "maxLength": 2048,
               "type": "string"
             },
             "ports": {
               "additionalProperties": {
                 "maximum": 4294967295,
                 "minimum": 0,
-                "type": "integer"
+                "type": "integer",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               },
               "description": "Set of ports associated with the endpoint.",
-              "type": "object"
+              "maxProperties": 128,
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "port name must be valid",
+                  "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                }
+              ]
             },
             "serviceAccount": {
               "description": "The service account associated with the workload if a sidecar is present in the workload.",
+              "maxLength": 253,
               "type": "string"
             },
             "weight": {
@@ -209,6 +237,16 @@
             }
           },
           "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Address is required",
+              "rule": "has(self.address) || has(self.network)"
+            },
+            {
+              "message": "UDS may not include ports",
+              "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+            }
+          ],
           "additionalProperties": false
         }
       },

--- a/master-standalone/applicationset-argoproj-v1alpha1.json
+++ b/master-standalone/applicationset-argoproj-v1alpha1.json
@@ -8318,6 +8318,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 },
@@ -8429,6 +8447,21 @@
                               "properties": {
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "insecure": {
                                   "type": "boolean"
@@ -9493,6 +9526,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 }
@@ -9613,6 +9664,21 @@
                                 },
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "group": {
                                   "type": "string"
@@ -16115,6 +16181,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 },
@@ -16226,6 +16310,21 @@
                               "properties": {
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "insecure": {
                                   "type": "boolean"
@@ -17290,6 +17389,24 @@
                                   ],
                                   "type": "object"
                                 },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
                                 "project": {
                                   "type": "string"
                                 }
@@ -17410,6 +17527,21 @@
                                 },
                                 "api": {
                                   "type": "string"
+                                },
+                                "caRef": {
+                                  "properties": {
+                                    "configMapName": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "configMapName",
+                                    "key"
+                                  ],
+                                  "type": "object"
                                 },
                                 "group": {
                                   "type": "string"
@@ -20296,6 +20428,24 @@
                         ],
                         "type": "object"
                       },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
                       "project": {
                         "type": "string"
                       },
@@ -20407,6 +20557,21 @@
                     "properties": {
                       "api": {
                         "type": "string"
+                      },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
                       },
                       "insecure": {
                         "type": "boolean"
@@ -21471,6 +21636,24 @@
                         ],
                         "type": "object"
                       },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
                       "project": {
                         "type": "string"
                       }
@@ -21591,6 +21774,21 @@
                       },
                       "api": {
                         "type": "string"
+                      },
+                      "caRef": {
+                        "properties": {
+                          "configMapName": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "configMapName",
+                          "key"
+                        ],
+                        "type": "object"
                       },
                       "group": {
                         "type": "string"

--- a/master-standalone/clustersecretstore-external-secrets-v1beta1.json
+++ b/master-standalone/clustersecretstore-external-secrets-v1beta1.json
@@ -2860,6 +2860,13 @@
                   "description": "ForwardInconsistent tells Vault to forward read-after-write requests to the Vault\nleader instead of simply retrying within a loop. This can increase performance if\nthe option is enabled serverside.\nhttps://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header",
                   "type": "boolean"
                 },
+                "headers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Headers to be added in Vault request",
+                  "type": "object"
+                },
                 "namespace": {
                   "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows\nVault environments to support Secure Multi-tenancy. e.g: \"ns1\".\nMore about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
                   "type": "string"

--- a/master-standalone/destinationrule-networking-v1.json
+++ b/master-standalone/destinationrule-networking-v1.json
@@ -292,13 +292,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -757,13 +751,7 @@
                                     },
                                     "ttl": {
                                       "description": "Lifetime of the cookie.",
-                                      "type": "string",
-                                      "x-kubernetes-validations": [
-                                        {
-                                          "message": "must be a valid duration greater than 1ms",
-                                          "rule": "duration(self) >= duration('1ms')"
-                                        }
-                                      ]
+                                      "type": "string"
                                     }
                                   },
                                   "required": [
@@ -1391,13 +1379,7 @@
                         },
                         "ttl": {
                           "description": "Lifetime of the cookie.",
-                          "type": "string",
-                          "x-kubernetes-validations": [
-                            {
-                              "message": "must be a valid duration greater than 1ms",
-                              "rule": "duration(self) >= duration('1ms')"
-                            }
-                          ]
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -1856,13 +1838,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [

--- a/master-standalone/destinationrule-networking-v1alpha3.json
+++ b/master-standalone/destinationrule-networking-v1alpha3.json
@@ -292,13 +292,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -757,13 +751,7 @@
                                     },
                                     "ttl": {
                                       "description": "Lifetime of the cookie.",
-                                      "type": "string",
-                                      "x-kubernetes-validations": [
-                                        {
-                                          "message": "must be a valid duration greater than 1ms",
-                                          "rule": "duration(self) >= duration('1ms')"
-                                        }
-                                      ]
+                                      "type": "string"
                                     }
                                   },
                                   "required": [
@@ -1391,13 +1379,7 @@
                         },
                         "ttl": {
                           "description": "Lifetime of the cookie.",
-                          "type": "string",
-                          "x-kubernetes-validations": [
-                            {
-                              "message": "must be a valid duration greater than 1ms",
-                              "rule": "duration(self) >= duration('1ms')"
-                            }
-                          ]
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -1856,13 +1838,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [

--- a/master-standalone/destinationrule-networking-v1beta1.json
+++ b/master-standalone/destinationrule-networking-v1beta1.json
@@ -292,13 +292,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -757,13 +751,7 @@
                                     },
                                     "ttl": {
                                       "description": "Lifetime of the cookie.",
-                                      "type": "string",
-                                      "x-kubernetes-validations": [
-                                        {
-                                          "message": "must be a valid duration greater than 1ms",
-                                          "rule": "duration(self) >= duration('1ms')"
-                                        }
-                                      ]
+                                      "type": "string"
                                     }
                                   },
                                   "required": [
@@ -1391,13 +1379,7 @@
                         },
                         "ttl": {
                           "description": "Lifetime of the cookie.",
-                          "type": "string",
-                          "x-kubernetes-validations": [
-                            {
-                              "message": "must be a valid duration greater than 1ms",
-                              "rule": "duration(self) >= duration('1ms')"
-                            }
-                          ]
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -1856,13 +1838,7 @@
                               },
                               "ttl": {
                                 "description": "Lifetime of the cookie.",
-                                "type": "string",
-                                "x-kubernetes-validations": [
-                                  {
-                                    "message": "must be a valid duration greater than 1ms",
-                                    "rule": "duration(self) >= duration('1ms')"
-                                  }
-                                ]
+                                "type": "string"
                               }
                             },
                             "required": [

--- a/master-standalone/freight-kargo-v1alpha1.json
+++ b/master-standalone/freight-kargo-v1alpha1.json
@@ -49,7 +49,7 @@
             "type": "string"
           },
           "healthCheckCommit": {
-            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
             "type": "string"
           },
           "id": {
@@ -106,6 +106,27 @@
     "metadata": {
       "type": "object"
     },
+    "origin": {
+      "description": "Origin describes a kind of Freight in terms of its origin.",
+      "properties": {
+        "kind": {
+          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+          "enum": [
+            "Warehouse"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
     "status": {
       "description": "Status describes the current status of this Freight.",
       "properties": {
@@ -129,7 +150,7 @@
       "type": "object"
     },
     "warehouse": {
-      "description": "Warehouse is the name of the Warehouse that created this Freight. This is a\nrequired field. TODO: It is not clear yet how this field should be set in\nthe case of user-defined Freight.",
+      "description": "Warehouse is the name of the Warehouse that created this Freight. This is a\nrequired field. TODO: It is not clear yet how this field should be set in\nthe case of user-defined Freight.\n\n\nDeprecated: Use Origin instead.",
       "type": "string"
     }
   },

--- a/master-standalone/ingressclassparams-elbv2-v1beta1.json
+++ b/master-standalone/ingressclassparams-elbv2-v1beta1.json
@@ -2,11 +2,11 @@
   "description": "IngressClassParams is the Schema for the IngressClassParams API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -15,6 +15,13 @@
     "spec": {
       "description": "IngressClassParamsSpec defines the desired state of IngressClassParams",
       "properties": {
+        "certificateArn": {
+          "description": "CertificateArn specifies the ARN of the certificates for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "group": {
           "description": "Group defines the IngressGroup for all Ingresses that belong to IngressClass with this IngressClassParams.",
           "properties": {
@@ -28,11 +35,19 @@
           ],
           "type": "object"
         },
+        "inboundCIDRs": {
+          "description": "InboundCIDRs specifies the CIDRs that are allowed to access the Ingresses that belong to IngressClass with this IngressClassParams.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "ipAddressType": {
           "description": "IPAddressType defines the ip address type for all Ingresses that belong to IngressClass with this IngressClassParams.",
           "enum": [
             "ipv4",
-            "dualstack"
+            "dualstack",
+            "dualstack-without-public-ipv4"
           ],
           "type": "string"
         },
@@ -59,27 +74,28 @@
           "type": "array"
         },
         "namespaceSelector": {
-          "description": "NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams. * if absent or present but empty, it selects all namespaces.",
+          "description": "NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams.\n* if absent or present but empty, it selects all namespaces.",
           "properties": {
             "matchExpressions": {
               "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
                     "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "required": [
@@ -88,17 +104,19 @@
                 ],
                 "type": "object"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "matchLabels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
-          "type": "object"
+          "type": "object",
+          "x-kubernetes-map-type": "atomic"
         },
         "scheme": {
           "description": "Scheme defines the scheme for all Ingresses that belong to IngressClass with this IngressClassParams.",
@@ -107,6 +125,36 @@
             "internet-facing"
           ],
           "type": "string"
+        },
+        "sslPolicy": {
+          "description": "SSLPolicy specifies the SSL Policy for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "type": "string"
+        },
+        "subnets": {
+          "description": "Subnets defines the subnets for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "properties": {
+            "ids": {
+              "description": "IDs specify the resource IDs of subnets. Exactly one of this or `tags` must be specified.",
+              "items": {
+                "description": "SubnetID specifies a subnet ID.",
+                "pattern": "subnet-[0-9a-f]+",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "tags": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "Tags specifies subnets in the load balancer's VPC where each\ntag specified in the map key contains one of the values in the corresponding\nvalue list.\nExactly one of this or `ids` must be specified.",
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
         "tags": {
           "description": "Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.",

--- a/master-standalone/promotion-kargo-v1alpha1.json
+++ b/master-standalone/promotion-kargo-v1alpha1.json
@@ -84,7 +84,7 @@
                     "type": "string"
                   },
                   "healthCheckCommit": {
-                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                     "type": "string"
                   },
                   "id": {
@@ -138,10 +138,31 @@
               "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
               "type": "string"
             },
+            "origin": {
+              "description": "Origin describes a kind of Freight in terms of its origin.",
+              "properties": {
+                "kind": {
+                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                  "enum": [
+                    "Warehouse"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object"
+            },
             "verificationHistory": {
-              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "items": {
-                "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                 "properties": {
                   "actor": {
                     "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -198,7 +219,7 @@
               "type": "array"
             },
             "verificationInfo": {
-              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "properties": {
                 "actor": {
                   "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -253,10 +274,325 @@
               "type": "object"
             },
             "warehouse": {
-              "description": "Warehouse is the name of the Warehouse that created this Freight.",
+              "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
               "type": "string"
             }
           },
+          "type": "object"
+        },
+        "freightCollection": {
+          "description": "FreightCollection contains the details of the piece of Freight referenced\nby this Promotion as well as any additional Freight that is carried over\nfrom the target Stage's current state.",
+          "properties": {
+            "id": {
+              "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+              "type": "string"
+            },
+            "items": {
+              "additionalProperties": {
+                "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                "properties": {
+                  "charts": {
+                    "description": "Charts describes specific versions of specific Helm charts.",
+                    "items": {
+                      "description": "Chart describes a specific version of a Helm chart.",
+                      "properties": {
+                        "name": {
+                          "description": "Name specifies the name of the chart.",
+                          "type": "string"
+                        },
+                        "repoURL": {
+                          "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version specifies a particular version of the chart.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "commits": {
+                    "description": "Commits describes specific Git repository commits.",
+                    "items": {
+                      "description": "GitCommit describes a specific commit from a specific Git repository.",
+                      "properties": {
+                        "author": {
+                          "description": "Author is the author of the commit.",
+                          "type": "string"
+                        },
+                        "branch": {
+                          "description": "Branch denotes the branch of the repository where this commit was found.",
+                          "type": "string"
+                        },
+                        "committer": {
+                          "description": "Committer is the person who committed the commit.",
+                          "type": "string"
+                        },
+                        "healthCheckCommit": {
+                          "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                          "type": "string"
+                        },
+                        "repoURL": {
+                          "description": "RepoURL is the URL of a Git repository.",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "images": {
+                    "description": "Images describes specific versions of specific container images.",
+                    "items": {
+                      "description": "Image describes a specific version of a container image.",
+                      "properties": {
+                        "digest": {
+                          "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                          "type": "string"
+                        },
+                        "gitRepoURL": {
+                          "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                          "type": "string"
+                        },
+                        "repoURL": {
+                          "description": "RepoURL describes the repository in which the image can be found.",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                    "type": "string"
+                  },
+                  "origin": {
+                    "description": "Origin describes a kind of Freight in terms of its origin.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                        "enum": [
+                          "Warehouse"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "verificationHistory": {
+                    "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                    "items": {
+                      "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                      "properties": {
+                        "actor": {
+                          "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                          "type": "string"
+                        },
+                        "analysisRun": {
+                          "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "phase": {
+                              "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "namespace",
+                            "phase"
+                          ],
+                          "type": "object"
+                        },
+                        "finishTime": {
+                          "description": "FinishTime is the time at which the Verification process finished.",
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the identifier of the Verification process.",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                          "type": "string"
+                        },
+                        "phase": {
+                          "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                          "type": "string"
+                        },
+                        "startTime": {
+                          "description": "StartTime is the time at which the Verification process was started.",
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "verificationInfo": {
+                    "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                    "properties": {
+                      "actor": {
+                        "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                        "type": "string"
+                      },
+                      "analysisRun": {
+                        "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the AnalysisRun.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace is the namespace of the AnalysisRun.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "namespace",
+                          "phase"
+                        ],
+                        "type": "object"
+                      },
+                      "finishTime": {
+                        "description": "FinishTime is the time at which the Verification process finished.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "ID is the identifier of the Verification process.",
+                        "type": "string"
+                      },
+                      "message": {
+                        "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                        "type": "string"
+                      },
+                      "phase": {
+                        "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                        "type": "string"
+                      },
+                      "startTime": {
+                        "description": "StartTime is the time at which the Verification process was started.",
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "warehouse": {
+                    "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+              "type": "object"
+            },
+            "verificationHistory": {
+              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+              "items": {
+                "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                "properties": {
+                  "actor": {
+                    "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                    "type": "string"
+                  },
+                  "analysisRun": {
+                    "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the name of the AnalysisRun.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace is the namespace of the AnalysisRun.",
+                        "type": "string"
+                      },
+                      "phase": {
+                        "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "namespace",
+                      "phase"
+                    ],
+                    "type": "object"
+                  },
+                  "finishTime": {
+                    "description": "FinishTime is the time at which the Verification process finished.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID is the identifier of the Verification process.",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                    "type": "string"
+                  },
+                  "phase": {
+                    "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "StartTime is the time at which the Verification process was started.",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
           "type": "object"
         },
         "lastHandledRefresh": {

--- a/master-standalone/secretstore-external-secrets-v1beta1.json
+++ b/master-standalone/secretstore-external-secrets-v1beta1.json
@@ -2860,6 +2860,13 @@
                   "description": "ForwardInconsistent tells Vault to forward read-after-write requests to the Vault\nleader instead of simply retrying within a loop. This can increase performance if\nthe option is enabled serverside.\nhttps://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header",
                   "type": "boolean"
                 },
+                "headers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Headers to be added in Vault request",
+                  "type": "object"
+                },
                 "namespace": {
                   "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows\nVault environments to support Secure Multi-tenancy. e.g: \"ns1\".\nMore about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
                   "type": "string"

--- a/master-standalone/serviceentry-networking-v1.json
+++ b/master-standalone/serviceentry-networking-v1.json
@@ -16,34 +16,62 @@
             "properties": {
               "address": {
                 "description": "Address associated with the network endpoint without the port.",
-                "type": "string"
+                "maxLength": 256,
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "UDS must be an absolute path or abstract socket",
+                    "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                  },
+                  {
+                    "message": "UDS may not be a dir",
+                    "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                  }
+                ]
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "One or more labels associated with the endpoint.",
+                "maxProperties": 256,
                 "type": "object"
               },
               "locality": {
                 "description": "The locality associated with the endpoint.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "network": {
                 "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "ports": {
                 "additionalProperties": {
                   "maximum": 4294967295,
                   "minimum": 0,
-                  "type": "integer"
+                  "type": "integer",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 },
                 "description": "Set of ports associated with the endpoint.",
-                "type": "object"
+                "maxProperties": 128,
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port name must be valid",
+                    "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                  }
+                ]
               },
               "serviceAccount": {
                 "description": "The service account associated with the workload if a sidecar is present in the workload.",
+                "maxLength": 253,
                 "type": "string"
               },
               "weight": {
@@ -53,8 +81,19 @@
                 "type": "integer"
               }
             },
-            "type": "object"
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "Address is required",
+                "rule": "has(self.address) || has(self.network)"
+              },
+              {
+                "message": "UDS may not include ports",
+                "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+              }
+            ]
           },
+          "maxItems": 4096,
           "type": "array"
         },
         "exportTo": {

--- a/master-standalone/serviceentry-networking-v1alpha3.json
+++ b/master-standalone/serviceentry-networking-v1alpha3.json
@@ -16,34 +16,62 @@
             "properties": {
               "address": {
                 "description": "Address associated with the network endpoint without the port.",
-                "type": "string"
+                "maxLength": 256,
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "UDS must be an absolute path or abstract socket",
+                    "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                  },
+                  {
+                    "message": "UDS may not be a dir",
+                    "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                  }
+                ]
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "One or more labels associated with the endpoint.",
+                "maxProperties": 256,
                 "type": "object"
               },
               "locality": {
                 "description": "The locality associated with the endpoint.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "network": {
                 "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "ports": {
                 "additionalProperties": {
                   "maximum": 4294967295,
                   "minimum": 0,
-                  "type": "integer"
+                  "type": "integer",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 },
                 "description": "Set of ports associated with the endpoint.",
-                "type": "object"
+                "maxProperties": 128,
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port name must be valid",
+                    "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                  }
+                ]
               },
               "serviceAccount": {
                 "description": "The service account associated with the workload if a sidecar is present in the workload.",
+                "maxLength": 253,
                 "type": "string"
               },
               "weight": {
@@ -53,8 +81,19 @@
                 "type": "integer"
               }
             },
-            "type": "object"
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "Address is required",
+                "rule": "has(self.address) || has(self.network)"
+              },
+              {
+                "message": "UDS may not include ports",
+                "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+              }
+            ]
           },
+          "maxItems": 4096,
           "type": "array"
         },
         "exportTo": {

--- a/master-standalone/serviceentry-networking-v1beta1.json
+++ b/master-standalone/serviceentry-networking-v1beta1.json
@@ -16,34 +16,62 @@
             "properties": {
               "address": {
                 "description": "Address associated with the network endpoint without the port.",
-                "type": "string"
+                "maxLength": 256,
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "UDS must be an absolute path or abstract socket",
+                    "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                  },
+                  {
+                    "message": "UDS may not be a dir",
+                    "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                  }
+                ]
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "One or more labels associated with the endpoint.",
+                "maxProperties": 256,
                 "type": "object"
               },
               "locality": {
                 "description": "The locality associated with the endpoint.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "network": {
                 "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+                "maxLength": 2048,
                 "type": "string"
               },
               "ports": {
                 "additionalProperties": {
                   "maximum": 4294967295,
                   "minimum": 0,
-                  "type": "integer"
+                  "type": "integer",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 },
                 "description": "Set of ports associated with the endpoint.",
-                "type": "object"
+                "maxProperties": 128,
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port name must be valid",
+                    "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                  }
+                ]
               },
               "serviceAccount": {
                 "description": "The service account associated with the workload if a sidecar is present in the workload.",
+                "maxLength": 253,
                 "type": "string"
               },
               "weight": {
@@ -53,8 +81,19 @@
                 "type": "integer"
               }
             },
-            "type": "object"
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "Address is required",
+                "rule": "has(self.address) || has(self.network)"
+              },
+              {
+                "message": "UDS may not include ports",
+                "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+              }
+            ]
           },
+          "maxItems": 4096,
           "type": "array"
         },
         "exportTo": {

--- a/master-standalone/stage-kargo-v1alpha1.json
+++ b/master-standalone/stage-kargo-v1alpha1.json
@@ -34,6 +34,27 @@
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                     "type": "string"
                   },
+                  "origin": {
+                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional, but Promotions will fail if there\nis ever ambiguity regarding which piece of Freight from which an artifact\nis to be sourced.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                        "enum": [
+                          "Warehouse"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
                   "sourceUpdates": {
                     "description": "SourceUpdates describes updates to be applied to various sources of the\nspecified Argo CD Application resource.",
                     "items": {
@@ -61,6 +82,27 @@
                                     "minLength": 1,
                                     "type": "string"
                                   },
+                                  "origin": {
+                                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDHelm's Origin field. If\nthat, too, is unspecified, Promotions will fail if there is ever ambiguity\nregarding from which piece of Freight an artifact is to be sourced.",
+                                    "properties": {
+                                      "kind": {
+                                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                        "enum": [
+                                          "Warehouse"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
                                   "value": {
                                     "description": "Value specifies the new value for the specified key in the Argo CD\nApplication's Helm parameters. Valid values are:\n\n\n- ImageAndTag: Replaces the value of the specified key with\n  <image name>:<tag>\n- Tag: Replaces the value of the specified key with just the new tag\n- ImageAndDigest: Replaces the value of the specified key with\n  <image name>@<digest>\n- Digest: Replaces the value of the specified key with just the new digest.\n\n\nThis is a required field.",
                                     "enum": [
@@ -81,6 +123,27 @@
                               },
                               "minItems": 1,
                               "type": "array"
+                            },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDSourceUpdate's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
                             }
                           },
                           "required": [
@@ -101,6 +164,27 @@
                                     "minLength": 1,
                                     "type": "string"
                                   },
+                                  "origin": {
+                                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDKustomize's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                                    "properties": {
+                                      "kind": {
+                                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                        "enum": [
+                                          "Warehouse"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
                                   "useDigest": {
                                     "description": "UseDigest specifies whether the image's digest should be used instead of\nits tag.",
                                     "type": "boolean"
@@ -113,10 +197,52 @@
                               },
                               "minItems": 1,
                               "type": "array"
+                            },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDSourceUpdate's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
                             }
                           },
                           "required": [
                             "images"
+                          ],
+                          "type": "object"
+                        },
+                        "origin": {
+                          "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing ArgoCDAppUpdate's Origin\nfield. If that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                          "properties": {
+                            "kind": {
+                              "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                              "enum": [
+                                "Warehouse"
+                              ],
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
                           ],
                           "type": "object"
                         },
@@ -169,6 +295,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing HelmPromotionMechanism's\nOrigin field. If that, too, is unspecified, Promotions will fail if there\nis ever ambiguity regarding from which piece of Freight an artifact is to\nbe sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "repository": {
                               "description": "Repository along with Name identifies a subchart of the umbrella chart at\nChartPath whose version should be updated. The values of both fields should\nexactly match the values of the fields of the same names in a dependency\nexpressed in the Chart.yaml of the umbrella chart at ChartPath. i.e. Do not\nmatch the values of these two fields to your Warehouse; match them to the\nChart.yaml. This is a required field.",
                               "minLength": 1,
@@ -201,6 +348,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing HelmPromotionMechanism's\nOrigin field. If that, too, is unspecified, Promotions will fail if there\nis ever ambiguity regarding from which piece of Freight an artifact is to\nbe sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "value": {
                               "description": "Value specifies the new value for the specified key in the specified Helm\nvalues file. Valid values are:\n\n\n- ImageAndTag: Replaces the value of the specified key with\n  <image name>:<tag>\n- Tag: Replaces the value of the specified key with just the new tag\n- ImageAndDigest: Replaces the value of the specified key with\n  <image name>@<digest>\n- Digest: Replaces the value of the specified key with just the new digest.\n\n\nThis is a required field.",
                               "enum": [
@@ -227,6 +395,27 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "origin": {
+                        "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing GitRepoUpdate's Origin field.\nIf that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                            "enum": [
+                              "Warehouse"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -248,6 +437,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing KustomizePromotionMechanism's\nOrigin field. If that, too, is unspecified, Promotions will fail if there\nis ever ambiguity regarding from which piece of Freight an artifact is to\nbe sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "path": {
                               "description": "Path specifies a path in which the `kustomize edit set image` command\nshould be executed. This is a required field.",
                               "minLength": 1,
@@ -267,10 +477,52 @@
                         },
                         "minItems": 1,
                         "type": "array"
+                      },
+                      "origin": {
+                        "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing GitRepoUpdate's Origin field.\nIf that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                            "enum": [
+                              "Warehouse"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object"
                       }
                     },
                     "required": [
                       "images"
+                    ],
+                    "type": "object"
+                  },
+                  "origin": {
+                    "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, the branch\nchecked out by this promotion mechanism will be the one specified by the\nReadBranch field. If that, too, is unspecified, the default branch of the\nrepository will be checked out. Always provide a value for this field if\nwishing to check out a specific commit indicated by a piece of Freight.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                        "enum": [
+                          "Warehouse"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
                     ],
                     "type": "object"
                   },
@@ -306,6 +558,27 @@
                               "minLength": 1,
                               "type": "string"
                             },
+                            "origin": {
+                              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing\nKargoRenderPromotionMechanism's Origin field. If that, too, is unspecified,\nPromotions will fail if there is ever ambiguity regarding from which piece\nof Freight an artifact is to be sourced.",
+                              "properties": {
+                                "kind": {
+                                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                  "enum": [
+                                    "Warehouse"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
                             "useDigest": {
                               "description": "UseDigest specifies whether the image's digest should be used instead of\nits tag.",
                               "type": "boolean"
@@ -317,6 +590,27 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "origin": {
+                        "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. When left unspecified, it will\nimplicitly inherit the value of the enclosing GitRepoUpdate's Origin field.\nIf that, too, is unspecified, Promotions will fail if there is ever\nambiguity regarding from which piece of Freight an artifact is to be\nsourced.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                            "enum": [
+                              "Warehouse"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -341,21 +635,95 @@
                 "type": "object"
               },
               "type": "array"
+            },
+            "origin": {
+              "description": "Origin disambiguates the origin from which artifacts used by this promotion\nmechanism must have originated. This is especially useful in cases where a\nStage may request Freight from multiples origins (e.g. multiple Warehouses)\nand some of those each reference different versions of artifacts from the\nsame repository. This field is optional. Its value is overridable by\nchild promotion mechanisms.",
+              "properties": {
+                "kind": {
+                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                  "enum": [
+                    "Warehouse"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object"
             }
           },
           "type": "object"
+        },
+        "requestedFreight": {
+          "description": "RequestedFreight expresses the Stage's need for certain pieces of Freight,\neach having originated from a particular Warehouse. This list must be\nnon-empty. In the common case, a Stage will request Freight having\noriginated from just one specific Warehouse. In advanced cases, requesting\nFreight from multiple Warehouses provides a method of advancing new\nartifacts of different types through parallel pipelines at different\nspeeds. This can be useful, for instance, if a Stage is home to multiple\nmicroservices that are independently versioned.",
+          "items": {
+            "description": "FreightRequest expresses a Stage's need for Freight having originated from a\nparticular Warehouse.",
+            "properties": {
+              "origin": {
+                "description": "Origin specifies from where the requested Freight must have originated.\nThis is a required field.",
+                "properties": {
+                  "kind": {
+                    "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                    "enum": [
+                      "Warehouse"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "sources": {
+                "description": "Sources describes where the requested Freight may be obtained from. This is\na required field.",
+                "properties": {
+                  "direct": {
+                    "description": "Direct indicates the requested Freight may be obtained directly from the\nWarehouse from which it originated. If this field's value is false, then\nthe value of the Stages field must be non-empty. i.e. Between the two\nfields, at least one source must be specified.",
+                    "type": "boolean"
+                  },
+                  "stages": {
+                    "description": "Stages identifies other \"upstream\" Stages as potential sources of the\nrequested Freight. If this field's value is empty, then the value of the\nDirect field must be true. i.e. Between the two fields, at least on source\nmust be specified.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "origin",
+              "sources"
+            ],
+            "type": "object"
+          },
+          "minItems": 1,
+          "type": "array"
         },
         "shard": {
           "description": "Shard is the name of the shard that this Stage belongs to. This is an\noptional field. If not specified, the Stage will belong to the default\nshard. A defaulting webhook will sync the value of the\nkargo.akuity.io/shard label with the value of this field. When this field\nis empty, the webhook will ensure that label is absent.",
           "type": "string"
         },
         "subscriptions": {
-          "description": "Subscriptions describes the Stage's sources of Freight. This is a required\nfield.",
+          "description": "Subscriptions describes the Stage's sources of Freight. This is a required\nfield.\n\n\nDeprecated: Use RequestedFreight instead.",
           "properties": {
             "upstreamStages": {
               "description": "UpstreamStages identifies other Stages as potential sources of Freight\nfor this Stage. This field is mutually exclusive with the Repos field.",
               "items": {
-                "description": "StageSubscription defines a subscription to Freight from another Stage.",
+                "description": "StageSubscription defines a subscription to Freight from another Stage.\n\n\nDeprecated: Use FreightRequest instead.",
                 "properties": {
                   "name": {
                     "description": "Name specifies the name of a Stage.",
@@ -444,6 +812,7 @@
         }
       },
       "required": [
+        "requestedFreight",
         "subscriptions"
       ],
       "type": "object"
@@ -452,7 +821,7 @@
       "description": "Status describes the Stage's current and recent Freight, health, and more.",
       "properties": {
         "currentFreight": {
-          "description": "CurrentFreight is a simplified representation of the Stage's current\nFreight describing what is currently deployed to the Stage.",
+          "description": "CurrentFreight is a simplified representation of the Stage's current\nFreight describing what is currently deployed to the Stage.\n\n\nDeprecated: Use the top item in the FreightHistory stack instead.",
           "properties": {
             "charts": {
               "description": "Charts describes specific versions of specific Helm charts.",
@@ -494,7 +863,7 @@
                     "type": "string"
                   },
                   "healthCheckCommit": {
-                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                     "type": "string"
                   },
                   "id": {
@@ -548,10 +917,31 @@
               "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
               "type": "string"
             },
+            "origin": {
+              "description": "Origin describes a kind of Freight in terms of its origin.",
+              "properties": {
+                "kind": {
+                  "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                  "enum": [
+                    "Warehouse"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object"
+            },
             "verificationHistory": {
-              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+              "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "items": {
-                "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                 "properties": {
                   "actor": {
                     "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -608,7 +998,7 @@
               "type": "array"
             },
             "verificationInfo": {
-              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+              "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
               "properties": {
                 "actor": {
                   "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -663,7 +1053,7 @@
               "type": "object"
             },
             "warehouse": {
-              "description": "Warehouse is the name of the Warehouse that created this Freight.",
+              "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
               "type": "string"
             }
           },
@@ -720,7 +1110,7 @@
                         "type": "string"
                       },
                       "healthCheckCommit": {
-                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                         "type": "string"
                       },
                       "id": {
@@ -774,10 +1164,31 @@
                   "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                   "type": "string"
                 },
+                "origin": {
+                  "description": "Origin describes a kind of Freight in terms of its origin.",
+                  "properties": {
+                    "kind": {
+                      "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                      "enum": [
+                        "Warehouse"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object"
+                },
                 "verificationHistory": {
-                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "items": {
-                    "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                    "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                     "properties": {
                       "actor": {
                         "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -834,7 +1245,7 @@
                   "type": "array"
                 },
                 "verificationInfo": {
-                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "properties": {
                     "actor": {
                       "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -889,7 +1300,7 @@
                   "type": "object"
                 },
                 "warehouse": {
-                  "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                  "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                   "type": "string"
                 }
               },
@@ -950,7 +1361,7 @@
                             "type": "string"
                           },
                           "healthCheckCommit": {
-                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                             "type": "string"
                           },
                           "id": {
@@ -1004,10 +1415,31 @@
                       "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                       "type": "string"
                     },
+                    "origin": {
+                      "description": "Origin describes a kind of Freight in terms of its origin.",
+                      "properties": {
+                        "kind": {
+                          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                          "enum": [
+                            "Warehouse"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
                     "verificationHistory": {
-                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "items": {
-                        "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                         "properties": {
                           "actor": {
                             "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1064,7 +1496,7 @@
                       "type": "array"
                     },
                     "verificationInfo": {
-                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "properties": {
                         "actor": {
                           "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1119,10 +1551,325 @@
                       "type": "object"
                     },
                     "warehouse": {
-                      "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                      "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                       "type": "string"
                     }
                   },
+                  "type": "object"
+                },
+                "freightCollection": {
+                  "description": "FreightCollection contains the details of the piece of Freight referenced\nby this Promotion as well as any additional Freight that is carried over\nfrom the target Stage's current state.",
+                  "properties": {
+                    "id": {
+                      "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+                      "type": "string"
+                    },
+                    "items": {
+                      "additionalProperties": {
+                        "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                        "properties": {
+                          "charts": {
+                            "description": "Charts describes specific versions of specific Helm charts.",
+                            "items": {
+                              "description": "Chart describes a specific version of a Helm chart.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies the name of the chart.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "description": "Version specifies a particular version of the chart.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "commits": {
+                            "description": "Commits describes specific Git repository commits.",
+                            "items": {
+                              "description": "GitCommit describes a specific commit from a specific Git repository.",
+                              "properties": {
+                                "author": {
+                                  "description": "Author is the author of the commit.",
+                                  "type": "string"
+                                },
+                                "branch": {
+                                  "description": "Branch denotes the branch of the repository where this commit was found.",
+                                  "type": "string"
+                                },
+                                "committer": {
+                                  "description": "Committer is the person who committed the commit.",
+                                  "type": "string"
+                                },
+                                "healthCheckCommit": {
+                                  "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL is the URL of a Git repository.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "images": {
+                            "description": "Images describes specific versions of specific container images.",
+                            "items": {
+                              "description": "Image describes a specific version of a container image.",
+                              "properties": {
+                                "digest": {
+                                  "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                                  "type": "string"
+                                },
+                                "gitRepoURL": {
+                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL describes the repository in which the image can be found.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                            "type": "string"
+                          },
+                          "origin": {
+                            "description": "Origin describes a kind of Freight in terms of its origin.",
+                            "properties": {
+                              "kind": {
+                                "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                "enum": [
+                                  "Warehouse"
+                                ],
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "verificationHistory": {
+                            "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "items": {
+                              "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                              "properties": {
+                                "actor": {
+                                  "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                  "type": "string"
+                                },
+                                "analysisRun": {
+                                  "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "description": "Namespace is the namespace of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "phase": {
+                                      "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "namespace",
+                                    "phase"
+                                  ],
+                                  "type": "object"
+                                },
+                                "finishTime": {
+                                  "description": "FinishTime is the time at which the Verification process finished.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the identifier of the Verification process.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                  "type": "string"
+                                },
+                                "phase": {
+                                  "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                  "type": "string"
+                                },
+                                "startTime": {
+                                  "description": "StartTime is the time at which the Verification process was started.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "verificationInfo": {
+                            "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "properties": {
+                              "actor": {
+                                "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                "type": "string"
+                              },
+                              "analysisRun": {
+                                "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the name of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "phase": {
+                                    "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "namespace",
+                                  "phase"
+                                ],
+                                "type": "object"
+                              },
+                              "finishTime": {
+                                "description": "FinishTime is the time at which the Verification process finished.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "id": {
+                                "description": "ID is the identifier of the Verification process.",
+                                "type": "string"
+                              },
+                              "message": {
+                                "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                "type": "string"
+                              },
+                              "startTime": {
+                                "description": "StartTime is the time at which the Verification process was started.",
+                                "format": "date-time",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "warehouse": {
+                            "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+                      "type": "object"
+                    },
+                    "verificationHistory": {
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "items": {
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                        "properties": {
+                          "actor": {
+                            "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                            "type": "string"
+                          },
+                          "analysisRun": {
+                            "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "namespace",
+                              "phase"
+                            ],
+                            "type": "object"
+                          },
+                          "finishTime": {
+                            "description": "FinishTime is the time at which the Verification process finished.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the identifier of the Verification process.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                            "type": "string"
+                          },
+                          "startTime": {
+                            "description": "StartTime is the time at which the Verification process was started.",
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
                   "type": "object"
                 },
                 "lastHandledRefresh": {
@@ -1149,10 +1896,332 @@
             }
           },
           "required": [
-            "freight",
             "name"
           ],
           "type": "object"
+        },
+        "freightHistory": {
+          "description": "FreightHistory is a list of recent Freight selections that were deployed\nto the Stage. By default, the last ten Freight selections are stored.\nThe first item in the list is the most recent Freight selection and\ncurrently deployed to the Stage, subsequent items are older selections.",
+          "items": {
+            "description": "FreightCollection is a collection of FreightReferences, each of which\nrepresents a piece of Freight that has been selected for deployment to a\nStage.",
+            "properties": {
+              "id": {
+                "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+                "type": "string"
+              },
+              "items": {
+                "additionalProperties": {
+                  "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                  "properties": {
+                    "charts": {
+                      "description": "Charts describes specific versions of specific Helm charts.",
+                      "items": {
+                        "description": "Chart describes a specific version of a Helm chart.",
+                        "properties": {
+                          "name": {
+                            "description": "Name specifies the name of the chart.",
+                            "type": "string"
+                          },
+                          "repoURL": {
+                            "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "Version specifies a particular version of the chart.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "commits": {
+                      "description": "Commits describes specific Git repository commits.",
+                      "items": {
+                        "description": "GitCommit describes a specific commit from a specific Git repository.",
+                        "properties": {
+                          "author": {
+                            "description": "Author is the author of the commit.",
+                            "type": "string"
+                          },
+                          "branch": {
+                            "description": "Branch denotes the branch of the repository where this commit was found.",
+                            "type": "string"
+                          },
+                          "committer": {
+                            "description": "Committer is the person who committed the commit.",
+                            "type": "string"
+                          },
+                          "healthCheckCommit": {
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                            "type": "string"
+                          },
+                          "repoURL": {
+                            "description": "RepoURL is the URL of a Git repository.",
+                            "type": "string"
+                          },
+                          "tag": {
+                            "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "images": {
+                      "description": "Images describes specific versions of specific container images.",
+                      "items": {
+                        "description": "Image describes a specific version of a container image.",
+                        "properties": {
+                          "digest": {
+                            "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                            "type": "string"
+                          },
+                          "gitRepoURL": {
+                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                            "type": "string"
+                          },
+                          "repoURL": {
+                            "description": "RepoURL describes the repository in which the image can be found.",
+                            "type": "string"
+                          },
+                          "tag": {
+                            "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                      "type": "string"
+                    },
+                    "origin": {
+                      "description": "Origin describes a kind of Freight in terms of its origin.",
+                      "properties": {
+                        "kind": {
+                          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                          "enum": [
+                            "Warehouse"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "verificationHistory": {
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                      "items": {
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                        "properties": {
+                          "actor": {
+                            "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                            "type": "string"
+                          },
+                          "analysisRun": {
+                            "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "namespace",
+                              "phase"
+                            ],
+                            "type": "object"
+                          },
+                          "finishTime": {
+                            "description": "FinishTime is the time at which the Verification process finished.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the identifier of the Verification process.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                            "type": "string"
+                          },
+                          "startTime": {
+                            "description": "StartTime is the time at which the Verification process was started.",
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "verificationInfo": {
+                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                      "properties": {
+                        "actor": {
+                          "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                          "type": "string"
+                        },
+                        "analysisRun": {
+                          "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the AnalysisRun.",
+                              "type": "string"
+                            },
+                            "phase": {
+                              "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "namespace",
+                            "phase"
+                          ],
+                          "type": "object"
+                        },
+                        "finishTime": {
+                          "description": "FinishTime is the time at which the Verification process finished.",
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the identifier of the Verification process.",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                          "type": "string"
+                        },
+                        "phase": {
+                          "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                          "type": "string"
+                        },
+                        "startTime": {
+                          "description": "StartTime is the time at which the Verification process was started.",
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "warehouse": {
+                      "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+                "type": "object"
+              },
+              "verificationHistory": {
+                "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                "items": {
+                  "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                  "properties": {
+                    "actor": {
+                      "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                      "type": "string"
+                    },
+                    "analysisRun": {
+                      "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of the AnalysisRun.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the namespace of the AnalysisRun.",
+                          "type": "string"
+                        },
+                        "phase": {
+                          "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "namespace",
+                        "phase"
+                      ],
+                      "type": "object"
+                    },
+                    "finishTime": {
+                      "description": "FinishTime is the time at which the Verification process finished.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "ID is the identifier of the Verification process.",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                      "type": "string"
+                    },
+                    "phase": {
+                      "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                      "type": "string"
+                    },
+                    "startTime": {
+                      "description": "StartTime is the time at which the Verification process was started.",
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "freightSummary": {
+          "description": "FreightSummary is human-readable text maintained by the controller that\nsummarizes what Freight is currently deployed to the Stage. For Stages that\nrequest a single piece of Freight AND the request has been fulfilled, this\nfield will simply contain the name of the Freight. For Stages that request\na single piece of Freight AND the request has NOT been fulfilled, or for\nStages that request multiple pieces of Freight, this field will contain a\nsummary of fulfilled/requested Freight. The existence of this field is a\nworkaround for kubectl limitations so that this complex but valuable\ninformation can be displayed in a column in response to `kubectl get\nstages`.",
+          "type": "string"
         },
         "health": {
           "description": "Health is the Stage's last observed health.",
@@ -1230,7 +2299,7 @@
           "type": "object"
         },
         "history": {
-          "description": "History is a stack of recent Freight. By default, the last ten Freight are\nstored.",
+          "description": "History is a stack of recent Freight. By default, the last ten Freight are\nstored.\n\n\nDeprecated: Use the FreightHistory stack instead.",
           "items": {
             "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
             "properties": {
@@ -1274,7 +2343,7 @@
                       "type": "string"
                     },
                     "healthCheckCommit": {
-                      "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                      "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                       "type": "string"
                     },
                     "id": {
@@ -1328,10 +2397,31 @@
                 "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                 "type": "string"
               },
+              "origin": {
+                "description": "Origin describes a kind of Freight in terms of its origin.",
+                "properties": {
+                  "kind": {
+                    "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                    "enum": [
+                      "Warehouse"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name"
+                ],
+                "type": "object"
+              },
               "verificationHistory": {
-                "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                 "items": {
-                  "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                  "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                   "properties": {
                     "actor": {
                       "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1388,7 +2478,7 @@
                 "type": "array"
               },
               "verificationInfo": {
-                "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                 "properties": {
                   "actor": {
                     "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1443,7 +2533,7 @@
                 "type": "object"
               },
               "warehouse": {
-                "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                 "type": "string"
               }
             },
@@ -1506,7 +2596,7 @@
                         "type": "string"
                       },
                       "healthCheckCommit": {
-                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                         "type": "string"
                       },
                       "id": {
@@ -1560,10 +2650,31 @@
                   "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                   "type": "string"
                 },
+                "origin": {
+                  "description": "Origin describes a kind of Freight in terms of its origin.",
+                  "properties": {
+                    "kind": {
+                      "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                      "enum": [
+                        "Warehouse"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object"
+                },
                 "verificationHistory": {
-                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                  "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "items": {
-                    "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                    "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                     "properties": {
                       "actor": {
                         "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1620,7 +2731,7 @@
                   "type": "array"
                 },
                 "verificationInfo": {
-                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                  "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                   "properties": {
                     "actor": {
                       "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1675,7 +2786,7 @@
                   "type": "object"
                 },
                 "warehouse": {
-                  "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                  "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                   "type": "string"
                 }
               },
@@ -1736,7 +2847,7 @@
                             "type": "string"
                           },
                           "healthCheckCommit": {
-                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                             "type": "string"
                           },
                           "id": {
@@ -1790,10 +2901,31 @@
                       "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
                       "type": "string"
                     },
+                    "origin": {
+                      "description": "Origin describes a kind of Freight in terms of its origin.",
+                      "properties": {
+                        "kind": {
+                          "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                          "enum": [
+                            "Warehouse"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
                     "verificationHistory": {
-                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "items": {
-                        "description": "VerificationInfo contains information about the currently running\nVerification process.",
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
                         "properties": {
                           "actor": {
                             "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1850,7 +2982,7 @@
                       "type": "array"
                     },
                     "verificationInfo": {
-                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.",
+                      "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
                       "properties": {
                         "actor": {
                           "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
@@ -1905,10 +3037,325 @@
                       "type": "object"
                     },
                     "warehouse": {
-                      "description": "Warehouse is the name of the Warehouse that created this Freight.",
+                      "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
                       "type": "string"
                     }
                   },
+                  "type": "object"
+                },
+                "freightCollection": {
+                  "description": "FreightCollection contains the details of the piece of Freight referenced\nby this Promotion as well as any additional Freight that is carried over\nfrom the target Stage's current state.",
+                  "properties": {
+                    "id": {
+                      "description": "ID is a unique and deterministically calculated identifier for the\nFreightCollection. It is updated on each use of the UpdateOrPush method.",
+                      "type": "string"
+                    },
+                    "items": {
+                      "additionalProperties": {
+                        "description": "FreightReference is a simplified representation of a piece of Freight -- not\na root resource type.",
+                        "properties": {
+                          "charts": {
+                            "description": "Charts describes specific versions of specific Helm charts.",
+                            "items": {
+                              "description": "Chart describes a specific version of a Helm chart.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies the name of the chart.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL specifies the URL of a Helm chart repository. Classic chart\nrepositories (using HTTP/S) can contain differently named charts. When this\nfield points to such a repository, the Name field will specify the name of\nthe chart within the repository. In the case of a repository within an OCI\nregistry, the URL implicitly points to a specific chart and the Name field\nwill be empty.",
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "description": "Version specifies a particular version of the chart.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "commits": {
+                            "description": "Commits describes specific Git repository commits.",
+                            "items": {
+                              "description": "GitCommit describes a specific commit from a specific Git repository.",
+                              "properties": {
+                                "author": {
+                                  "description": "Author is the author of the commit.",
+                                  "type": "string"
+                                },
+                                "branch": {
+                                  "description": "Branch denotes the branch of the repository where this commit was found.",
+                                  "type": "string"
+                                },
+                                "committer": {
+                                  "description": "Committer is the person who committed the commit.",
+                                  "type": "string"
+                                },
+                                "healthCheckCommit": {
+                                  "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the ID of a specific commit in the Git repository specified by\nRepoURL.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message is the message associated with the commit. At present, this only\ncontains the first line (subject) of the commit message.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL is the URL of a Git repository.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag denotes a tag in the repository that matched selection criteria and\nresolved to this commit.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "images": {
+                            "description": "Images describes specific versions of specific container images.",
+                            "items": {
+                              "description": "Image describes a specific version of a container image.",
+                              "properties": {
+                                "digest": {
+                                  "description": "Digest identifies a specific version of the image in the repository\nspecified by RepoURL. This is a more precise identifier than Tag.",
+                                  "type": "string"
+                                },
+                                "gitRepoURL": {
+                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "description": "RepoURL describes the repository in which the image can be found.",
+                                  "type": "string"
+                                },
+                                "tag": {
+                                  "description": "Tag identifies a specific version of the image in the repository specified\nby RepoURL.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is system-assigned identifier that is derived deterministically from\nthe contents of the Freight. i.e. Two pieces of Freight can be compared for\nequality by comparing their Names.",
+                            "type": "string"
+                          },
+                          "origin": {
+                            "description": "Origin describes a kind of Freight in terms of its origin.",
+                            "properties": {
+                              "kind": {
+                                "description": "Kind is the kind of resource from which Freight may have originated. At\npresent, this can only be \"Warehouse\".",
+                                "enum": [
+                                  "Warehouse"
+                                ],
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the resource of the kind indicated by the Kind field\nfrom which Freight may originated.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "verificationHistory": {
+                            "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "items": {
+                              "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                              "properties": {
+                                "actor": {
+                                  "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                  "type": "string"
+                                },
+                                "analysisRun": {
+                                  "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "description": "Namespace is the namespace of the AnalysisRun.",
+                                      "type": "string"
+                                    },
+                                    "phase": {
+                                      "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "namespace",
+                                    "phase"
+                                  ],
+                                  "type": "object"
+                                },
+                                "finishTime": {
+                                  "description": "FinishTime is the time at which the Verification process finished.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "description": "ID is the identifier of the Verification process.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                  "type": "string"
+                                },
+                                "phase": {
+                                  "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                  "type": "string"
+                                },
+                                "startTime": {
+                                  "description": "StartTime is the time at which the Verification process was started.",
+                                  "format": "date-time",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "verificationInfo": {
+                            "description": "VerificationInfo is information about any verification process that was\nassociated with this Freight for this Stage.\n\n\nDeprecated: Use FreightCollection.VerificationHistory instead.",
+                            "properties": {
+                              "actor": {
+                                "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                                "type": "string"
+                              },
+                              "analysisRun": {
+                                "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the name of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the AnalysisRun.",
+                                    "type": "string"
+                                  },
+                                  "phase": {
+                                    "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "namespace",
+                                  "phase"
+                                ],
+                                "type": "object"
+                              },
+                              "finishTime": {
+                                "description": "FinishTime is the time at which the Verification process finished.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "id": {
+                                "description": "ID is the identifier of the Verification process.",
+                                "type": "string"
+                              },
+                              "message": {
+                                "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                                "type": "string"
+                              },
+                              "startTime": {
+                                "description": "StartTime is the time at which the Verification process was started.",
+                                "format": "date-time",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "warehouse": {
+                            "description": "Warehouse is the name of the Warehouse that created this Freight.\n\n\nDeprecated: Use the Origin instead.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "description": "Freight is a map of FreightReference objects, indexed by their Warehouse\norigin.",
+                      "type": "object"
+                    },
+                    "verificationHistory": {
+                      "description": "VerificationHistory is a stack of recent VerificationInfo. By default,\nthe last ten VerificationInfo are stored.",
+                      "items": {
+                        "description": "VerificationInfo contains the details of an instance of a Verification\nprocess.",
+                        "properties": {
+                          "actor": {
+                            "description": "Actor is the name of the entity that initiated or aborted the\nVerification process.",
+                            "type": "string"
+                          },
+                          "analysisRun": {
+                            "description": "AnalysisRun is a reference to the Argo Rollouts AnalysisRun that implements\nthe Verification process.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the AnalysisRun.",
+                                "type": "string"
+                              },
+                              "phase": {
+                                "description": "Phase is the last observed phase of the AnalysisRun referenced by Name.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "namespace",
+                              "phase"
+                            ],
+                            "type": "object"
+                          },
+                          "finishTime": {
+                            "description": "FinishTime is the time at which the Verification process finished.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID is the identifier of the Verification process.",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "Message may contain additional information about why the verification\nprocess is in its current phase.",
+                            "type": "string"
+                          },
+                          "phase": {
+                            "description": "Phase describes the current phase of the Verification process. Generally,\nthis will be a reflection of the underlying AnalysisRun's phase, however,\nthere are exceptions to this, such as in the case where an AnalysisRun\ncannot be launched successfully.",
+                            "type": "string"
+                          },
+                          "startTime": {
+                            "description": "StartTime is the time at which the Verification process was started.",
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
                   "type": "object"
                 },
                 "lastHandledRefresh": {
@@ -1935,7 +3382,6 @@
             }
           },
           "required": [
-            "freight",
             "name"
           ],
           "type": "object"

--- a/master-standalone/targetgroupbinding-elbv2-v1alpha1.json
+++ b/master-standalone/targetgroupbinding-elbv2-v1alpha1.json
@@ -2,11 +2,11 @@
   "description": "TargetGroupBinding is the Schema for the TargetGroupBinding API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -23,15 +23,15 @@
               "items": {
                 "properties": {
                   "from": {
-                    "description": "List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.",
+                    "description": "List of peers which should be able to access the targets in TargetGroup.\nAt least one NetworkingPeer should be specified.",
                     "items": {
                       "description": "NetworkingPeer defines the source/destination peer for networking rules.",
                       "properties": {
                         "ipBlock": {
-                          "description": "IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.",
+                          "description": "IPBlock defines an IPBlock peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "cidr": {
-                              "description": "CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.",
+                              "description": "CIDR is the network CIDR.\nBoth IPV4 or IPV6 CIDR are accepted.",
                               "type": "string"
                             }
                           },
@@ -41,7 +41,7 @@
                           "type": "object"
                         },
                         "securityGroup": {
-                          "description": "SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.",
+                          "description": "SecurityGroup defines a SecurityGroup peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "groupID": {
                               "description": "GroupID is the EC2 SecurityGroupID.",
@@ -59,7 +59,7 @@
                     "type": "array"
                   },
                   "ports": {
-                    "description": "List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.",
+                    "description": "List of ports which should be made accessible on the targets in TargetGroup.\nIf ports is empty or unspecified, it defaults to all ports with TCP.",
                     "items": {
                       "properties": {
                         "port": {
@@ -71,11 +71,11 @@
                               "type": "string"
                             }
                           ],
-                          "description": "The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.",
+                          "description": "The port which traffic must match.\nWhen NodePort endpoints(instance TargetType) is used, this must be a numerical port.\nWhen Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.\nif port is unspecified, it defaults to all ports.",
                           "x-kubernetes-int-or-string": true
                         },
                         "protocol": {
-                          "description": "The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.",
+                          "description": "The protocol which traffic must match.\nIf protocol is unspecified, it defaults to TCP.",
                           "enum": [
                             "TCP",
                             "UDP"

--- a/master-standalone/targetgroupbinding-elbv2-v1beta1.json
+++ b/master-standalone/targetgroupbinding-elbv2-v1beta1.json
@@ -2,11 +2,11 @@
   "description": "TargetGroupBinding is the Schema for the TargetGroupBinding API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -32,15 +32,15 @@
                 "description": "NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.",
                 "properties": {
                   "from": {
-                    "description": "List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.",
+                    "description": "List of peers which should be able to access the targets in TargetGroup.\nAt least one NetworkingPeer should be specified.",
                     "items": {
                       "description": "NetworkingPeer defines the source/destination peer for networking rules.",
                       "properties": {
                         "ipBlock": {
-                          "description": "IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.",
+                          "description": "IPBlock defines an IPBlock peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "cidr": {
-                              "description": "CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.",
+                              "description": "CIDR is the network CIDR.\nBoth IPV4 or IPV6 CIDR are accepted.",
                               "type": "string"
                             }
                           },
@@ -50,7 +50,7 @@
                           "type": "object"
                         },
                         "securityGroup": {
-                          "description": "SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.",
+                          "description": "SecurityGroup defines a SecurityGroup peer.\nIf specified, none of the other fields can be set.",
                           "properties": {
                             "groupID": {
                               "description": "GroupID is the EC2 SecurityGroupID.",
@@ -68,7 +68,7 @@
                     "type": "array"
                   },
                   "ports": {
-                    "description": "List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.",
+                    "description": "List of ports which should be made accessible on the targets in TargetGroup.\nIf ports is empty or unspecified, it defaults to all ports with TCP.",
                     "items": {
                       "description": "NetworkingPort defines the port and protocol for networking rules.",
                       "properties": {
@@ -81,11 +81,11 @@
                               "type": "string"
                             }
                           ],
-                          "description": "The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.",
+                          "description": "The port which traffic must match.\nWhen NodePort endpoints(instance TargetType) is used, this must be a numerical port.\nWhen Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.\nif port is unspecified, it defaults to all ports.",
                           "x-kubernetes-int-or-string": true
                         },
                         "protocol": {
-                          "description": "The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.",
+                          "description": "The protocol which traffic must match.\nIf protocol is unspecified, it defaults to TCP.",
                           "enum": [
                             "TCP",
                             "UDP"
@@ -115,22 +115,23 @@
             "matchExpressions": {
               "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
                     "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "required": [
@@ -139,17 +140,19 @@
                 ],
                 "type": "object"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "matchLabels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
-          "type": "object"
+          "type": "object",
+          "x-kubernetes-map-type": "atomic"
         },
         "serviceRef": {
           "description": "serviceRef is a reference to a Kubernetes Service and ServicePort.",
@@ -188,6 +191,10 @@
             "instance",
             "ip"
           ],
+          "type": "string"
+        },
+        "vpcID": {
+          "description": "VpcID is the VPC of the TargetGroup. If unspecified, it will be automatically inferred.",
           "type": "string"
         }
       },

--- a/master-standalone/vaultdynamicsecret-generators-v1alpha1.json
+++ b/master-standalone/vaultdynamicsecret-generators-v1alpha1.json
@@ -535,6 +535,13 @@
               "description": "ForwardInconsistent tells Vault to forward read-after-write requests to the Vault\nleader instead of simply retrying within a loop. This can increase performance if\nthe option is enabled serverside.\nhttps://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header",
               "type": "boolean"
             },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Headers to be added in Vault request",
+              "type": "object"
+            },
             "namespace": {
               "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows\nVault environments to support Secure Multi-tenancy. e.g: \"ns1\".\nMore about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
               "type": "string"

--- a/master-standalone/workloadentry-networking-v1.json
+++ b/master-standalone/workloadentry-networking-v1.json
@@ -5,34 +5,62 @@
       "properties": {
         "address": {
           "description": "Address associated with the network endpoint without the port.",
-          "type": "string"
+          "maxLength": 256,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS must be an absolute path or abstract socket",
+              "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+            },
+            {
+              "message": "UDS may not be a dir",
+              "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+            }
+          ]
         },
         "labels": {
           "additionalProperties": {
             "type": "string"
           },
           "description": "One or more labels associated with the endpoint.",
+          "maxProperties": 256,
           "type": "object"
         },
         "locality": {
           "description": "The locality associated with the endpoint.",
+          "maxLength": 2048,
           "type": "string"
         },
         "network": {
           "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+          "maxLength": 2048,
           "type": "string"
         },
         "ports": {
           "additionalProperties": {
             "maximum": 4294967295,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-kubernetes-validations": [
+              {
+                "message": "port must be between 1-65535",
+                "rule": "0 < self && self <= 65535"
+              }
+            ]
           },
           "description": "Set of ports associated with the endpoint.",
-          "type": "object"
+          "maxProperties": 128,
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port name must be valid",
+              "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+            }
+          ]
         },
         "serviceAccount": {
           "description": "The service account associated with the workload if a sidecar is present in the workload.",
+          "maxLength": 253,
           "type": "string"
         },
         "weight": {
@@ -42,12 +70,27 @@
           "type": "integer"
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "Address is required",
+          "rule": "has(self.address) || has(self.network)"
+        },
+        {
+          "message": "UDS may not include ports",
+          "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+        }
+      ]
     },
     "status": {
       "type": "object",
       "x-kubernetes-preserve-unknown-fields": true
     }
   },
+  "required": [
+    "spec",
+    "spec",
+    "spec"
+  ],
   "type": "object"
 }

--- a/master-standalone/workloadentry-networking-v1alpha3.json
+++ b/master-standalone/workloadentry-networking-v1alpha3.json
@@ -5,34 +5,62 @@
       "properties": {
         "address": {
           "description": "Address associated with the network endpoint without the port.",
-          "type": "string"
+          "maxLength": 256,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS must be an absolute path or abstract socket",
+              "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+            },
+            {
+              "message": "UDS may not be a dir",
+              "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+            }
+          ]
         },
         "labels": {
           "additionalProperties": {
             "type": "string"
           },
           "description": "One or more labels associated with the endpoint.",
+          "maxProperties": 256,
           "type": "object"
         },
         "locality": {
           "description": "The locality associated with the endpoint.",
+          "maxLength": 2048,
           "type": "string"
         },
         "network": {
           "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+          "maxLength": 2048,
           "type": "string"
         },
         "ports": {
           "additionalProperties": {
             "maximum": 4294967295,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-kubernetes-validations": [
+              {
+                "message": "port must be between 1-65535",
+                "rule": "0 < self && self <= 65535"
+              }
+            ]
           },
           "description": "Set of ports associated with the endpoint.",
-          "type": "object"
+          "maxProperties": 128,
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port name must be valid",
+              "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+            }
+          ]
         },
         "serviceAccount": {
           "description": "The service account associated with the workload if a sidecar is present in the workload.",
+          "maxLength": 253,
           "type": "string"
         },
         "weight": {
@@ -42,12 +70,27 @@
           "type": "integer"
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "Address is required",
+          "rule": "has(self.address) || has(self.network)"
+        },
+        {
+          "message": "UDS may not include ports",
+          "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+        }
+      ]
     },
     "status": {
       "type": "object",
       "x-kubernetes-preserve-unknown-fields": true
     }
   },
+  "required": [
+    "spec",
+    "spec",
+    "spec"
+  ],
   "type": "object"
 }

--- a/master-standalone/workloadentry-networking-v1beta1.json
+++ b/master-standalone/workloadentry-networking-v1beta1.json
@@ -5,34 +5,62 @@
       "properties": {
         "address": {
           "description": "Address associated with the network endpoint without the port.",
-          "type": "string"
+          "maxLength": 256,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS must be an absolute path or abstract socket",
+              "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+            },
+            {
+              "message": "UDS may not be a dir",
+              "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+            }
+          ]
         },
         "labels": {
           "additionalProperties": {
             "type": "string"
           },
           "description": "One or more labels associated with the endpoint.",
+          "maxProperties": 256,
           "type": "object"
         },
         "locality": {
           "description": "The locality associated with the endpoint.",
+          "maxLength": 2048,
           "type": "string"
         },
         "network": {
           "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+          "maxLength": 2048,
           "type": "string"
         },
         "ports": {
           "additionalProperties": {
             "maximum": 4294967295,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-kubernetes-validations": [
+              {
+                "message": "port must be between 1-65535",
+                "rule": "0 < self && self <= 65535"
+              }
+            ]
           },
           "description": "Set of ports associated with the endpoint.",
-          "type": "object"
+          "maxProperties": 128,
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port name must be valid",
+              "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+            }
+          ]
         },
         "serviceAccount": {
           "description": "The service account associated with the workload if a sidecar is present in the workload.",
+          "maxLength": 253,
           "type": "string"
         },
         "weight": {
@@ -42,12 +70,27 @@
           "type": "integer"
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "Address is required",
+          "rule": "has(self.address) || has(self.network)"
+        },
+        {
+          "message": "UDS may not include ports",
+          "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+        }
+      ]
     },
     "status": {
       "type": "object",
       "x-kubernetes-preserve-unknown-fields": true
     }
   },
+  "required": [
+    "spec",
+    "spec",
+    "spec"
+  ],
   "type": "object"
 }

--- a/master-standalone/workloadgroup-networking-v1.json
+++ b/master-standalone/workloadgroup-networking-v1.json
@@ -166,34 +166,62 @@
           "properties": {
             "address": {
               "description": "Address associated with the network endpoint without the port.",
-              "type": "string"
+              "maxLength": 256,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "UDS must be an absolute path or abstract socket",
+                  "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                },
+                {
+                  "message": "UDS may not be a dir",
+                  "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                }
+              ]
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
               "description": "One or more labels associated with the endpoint.",
+              "maxProperties": 256,
               "type": "object"
             },
             "locality": {
               "description": "The locality associated with the endpoint.",
+              "maxLength": 2048,
               "type": "string"
             },
             "network": {
               "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+              "maxLength": 2048,
               "type": "string"
             },
             "ports": {
               "additionalProperties": {
                 "maximum": 4294967295,
                 "minimum": 0,
-                "type": "integer"
+                "type": "integer",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               },
               "description": "Set of ports associated with the endpoint.",
-              "type": "object"
+              "maxProperties": 128,
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "port name must be valid",
+                  "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                }
+              ]
             },
             "serviceAccount": {
               "description": "The service account associated with the workload if a sidecar is present in the workload.",
+              "maxLength": 253,
               "type": "string"
             },
             "weight": {
@@ -203,7 +231,17 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Address is required",
+              "rule": "has(self.address) || has(self.network)"
+            },
+            {
+              "message": "UDS may not include ports",
+              "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+            }
+          ]
         }
       },
       "required": [

--- a/master-standalone/workloadgroup-networking-v1alpha3.json
+++ b/master-standalone/workloadgroup-networking-v1alpha3.json
@@ -166,34 +166,62 @@
           "properties": {
             "address": {
               "description": "Address associated with the network endpoint without the port.",
-              "type": "string"
+              "maxLength": 256,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "UDS must be an absolute path or abstract socket",
+                  "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                },
+                {
+                  "message": "UDS may not be a dir",
+                  "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                }
+              ]
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
               "description": "One or more labels associated with the endpoint.",
+              "maxProperties": 256,
               "type": "object"
             },
             "locality": {
               "description": "The locality associated with the endpoint.",
+              "maxLength": 2048,
               "type": "string"
             },
             "network": {
               "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+              "maxLength": 2048,
               "type": "string"
             },
             "ports": {
               "additionalProperties": {
                 "maximum": 4294967295,
                 "minimum": 0,
-                "type": "integer"
+                "type": "integer",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               },
               "description": "Set of ports associated with the endpoint.",
-              "type": "object"
+              "maxProperties": 128,
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "port name must be valid",
+                  "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                }
+              ]
             },
             "serviceAccount": {
               "description": "The service account associated with the workload if a sidecar is present in the workload.",
+              "maxLength": 253,
               "type": "string"
             },
             "weight": {
@@ -203,7 +231,17 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Address is required",
+              "rule": "has(self.address) || has(self.network)"
+            },
+            {
+              "message": "UDS may not include ports",
+              "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+            }
+          ]
         }
       },
       "required": [

--- a/master-standalone/workloadgroup-networking-v1beta1.json
+++ b/master-standalone/workloadgroup-networking-v1beta1.json
@@ -166,34 +166,62 @@
           "properties": {
             "address": {
               "description": "Address associated with the network endpoint without the port.",
-              "type": "string"
+              "maxLength": 256,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "UDS must be an absolute path or abstract socket",
+                  "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                },
+                {
+                  "message": "UDS may not be a dir",
+                  "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                }
+              ]
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
               "description": "One or more labels associated with the endpoint.",
+              "maxProperties": 256,
               "type": "object"
             },
             "locality": {
               "description": "The locality associated with the endpoint.",
+              "maxLength": 2048,
               "type": "string"
             },
             "network": {
               "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
+              "maxLength": 2048,
               "type": "string"
             },
             "ports": {
               "additionalProperties": {
                 "maximum": 4294967295,
                 "minimum": 0,
-                "type": "integer"
+                "type": "integer",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               },
               "description": "Set of ports associated with the endpoint.",
-              "type": "object"
+              "maxProperties": 128,
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "port name must be valid",
+                  "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                }
+              ]
             },
             "serviceAccount": {
               "description": "The service account associated with the workload if a sidecar is present in the workload.",
+              "maxLength": 253,
               "type": "string"
             },
             "weight": {
@@ -203,7 +231,17 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Address is required",
+              "rule": "has(self.address) || has(self.network)"
+            },
+            {
+              "message": "UDS may not include ports",
+              "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+            }
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
[SRES-3651]

* to resolve missing var in https://github.com/Frameio/gitops/pull/1611 updating schemas
* update ALB schema to 2.8.1, as that's what we use currently

[SRES-3651]: https://frame-io.atlassian.net/browse/SRES-3651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ